### PR TITLE
fix: walk cosmwasm in sorted keys order

### DIFF
--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -525,7 +525,7 @@ func ExtractCosmwasmTypes(parentType string, rootTypes typeddata.Types, obj refl
 }
 
 func SortedMapKeys(keys []reflect.Value) []reflect.Value {
-	sort.Slice(keys, func(i, j int) bool {
+	sort.SliceStable(keys, func(i, j int) bool {
 		return keys[i].String() < keys[j].String()
 	})
 	return keys

--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"reflect"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"time"
 
@@ -451,7 +452,7 @@ func doRecover(err *error) {
 }
 
 func trimEmptyArrays(obj reflect.Value) reflect.Value {
-	for _, k := range obj.MapKeys() {
+	for _, k := range SortedMapKeys(obj.MapKeys()) {
 		// if current level is object
 		if mapObj, ok := obj.Interface().(map[string]interface{}); ok {
 			// and its field is array
@@ -481,7 +482,7 @@ func trimEmptyArrays(obj reflect.Value) reflect.Value {
 }
 
 func ExtractCosmwasmTypes(parentType string, rootTypes typeddata.Types, obj reflect.Value) typeddata.Types {
-	for _, k := range obj.MapKeys() {
+	for _, k := range SortedMapKeys(obj.MapKeys()) {
 		switch field := obj.MapIndex(k).Interface().(type) {
 		// field is array
 		case []interface{}:
@@ -521,4 +522,11 @@ func ExtractCosmwasmTypes(parentType string, rootTypes typeddata.Types, obj refl
 	}
 
 	return rootTypes
+}
+
+func SortedMapKeys(keys []reflect.Value) []reflect.Value {
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	return keys
 }


### PR DESCRIPTION
Devnet randomly had apphash mismatch due to the cosmwasm msg construction use unsorted keys.

Initially I thought it walks through the data field and check the schema to encode, but actually it walks through the schema and encode the data in schema order. So inconsistent schema will lead to inconsistent encoded msg.

This PR sorts the `reflect.MapKeys()` as it's not sorted by default, been tested over 100 txs on devnet.
