### PR TITLE
F/gas price increment

### DIFF
--- a/client/common/options.go
+++ b/client/common/options.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
+	"time"
 )
 
 func init() {
@@ -18,9 +19,10 @@ func init() {
 }
 
 type ClientOptions struct {
-	GasPrices          string
-	GasPricesIncrement sdk.Dec
-	TLSCert            credentials.TransportCredentials
+	GasPrices             string
+	GasPricesIncrement    sdk.Dec
+	GasPriceResetInterval *time.Ticker
+	TLSCert               credentials.TransportCredentials
 }
 
 type ClientOption func(opts *ClientOptions) error
@@ -45,6 +47,17 @@ func OptionGasPrices(gasPrices string) ClientOption {
 func OptionGasPriceIncrement(percent int64) ClientOption {
 	return func(opts *ClientOptions) error {
 		opts.GasPricesIncrement = sdk.NewDecWithPrec(100+percent, 2)
+		return nil
+	}
+}
+
+func OptionsGasPriceResetInterval(ticker *time.Ticker) ClientOption {
+	return func(opts *ClientOptions) error {
+		if ticker != nil {
+			opts.GasPriceResetInterval = ticker
+		} else {
+			opts.GasPriceResetInterval = time.NewTicker(time.Minute * 5)
+		}
 		return nil
 	}
 }

--- a/client/common/options.go
+++ b/client/common/options.go
@@ -18,8 +18,9 @@ func init() {
 }
 
 type ClientOptions struct {
-	GasPrices string
-	TLSCert   credentials.TransportCredentials
+	GasPrices          string
+	GasPricesIncrement sdk.Dec
+	TLSCert            credentials.TransportCredentials
 }
 
 type ClientOption func(opts *ClientOptions) error
@@ -37,6 +38,13 @@ func OptionGasPrices(gasPrices string) ClientOption {
 		}
 
 		opts.GasPrices = gasPrices
+		return nil
+	}
+}
+
+func OptionGasPriceIncrement(percent int64) ClientOption {
+	return func(opts *ClientOptions) error {
+		opts.GasPricesIncrement = sdk.NewDecWithPrec(100+percent, 2)
 		return nil
 	}
 }


### PR DESCRIPTION
Add 2 new chain config options and hint to resolve tx timeout issue
* `common.OptionGasPriceIncrement(10)` every time `tx timed out` error happend, gas prices will be increased by 10% of current gas prices to prioritize txs into block inclusion when network is busy
* `common.OptionsGasPriceResetInterval(time.NewTicker(time.Minute*3))` gas prices will be reset back to baseline every 3 minutes to avoid wasting gas when network is not busy.


<img width="1792" alt="Screenshot 2023-02-20 at 16 18 20" src="https://user-images.githubusercontent.com/30719184/220064763-f46c59ef-31db-4ce0-a67b-4ac8da14e6fa.png">
