### PR TITLE
feat: support local order hash

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -155,6 +155,7 @@ type chainClient struct {
 	bankQueryClient     banktypes.QueryClient
 	authzQueryClient    authztypes.QueryClient
 	wasmQueryClient     wasmtypes.QueryClient
+	subaccountToNonce   map[ethcommon.Hash]uint32
 
 	closed  int64
 	canSign bool
@@ -230,6 +231,7 @@ func NewChainClient(
 		bankQueryClient:     banktypes.NewQueryClient(conn),
 		authzQueryClient:    authztypes.NewQueryClient(conn),
 		wasmQueryClient:     wasmtypes.NewQueryClient(conn),
+		subaccountToNonce:   make(map[ethcommon.Hash]uint32),
 	}
 
 	if cc.canSign {

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -104,6 +104,8 @@ type ChainClient interface {
 
 	GetSubAccountNonce(ctx context.Context, subaccountId eth.Hash) (*exchangetypes.QuerySubaccountTradeNonceResponse, error)
 	GetFeeDiscountInfo(ctx context.Context, account string) (*exchangetypes.QueryFeeDiscountAccountInfoResponse, error)
+
+	UpdateSubaccountNonceFromChain() error
 	ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, derivativeOrders []exchangetypes.DerivativeOrder) (OrderHashes, error)
 
 	SpotOrder(defaultSubaccountID eth.Hash, network common.Network, d *SpotOrderData) *exchangetypes.SpotOrder

--- a/client/chain/orderhash.go
+++ b/client/chain/orderhash.go
@@ -78,7 +78,7 @@ func (c *chainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, d
 	subaccountId := c.DefaultSubaccount(c.ctx.FromAddress)
 	if _, exist := c.subaccountToNonce[subaccountId]; !exist {
 		if err := c.UpdateSubaccountNonceFromChain(); err != nil {
-			return OrderHashes{}, nil
+			return OrderHashes{}, err
 		}
 	}
 


### PR DESCRIPTION
We don't need to query chain every time computing orderhash (orderhash is used to cancel, update orders). 2 benefits:
- Faster get orderhash
- Stop using some queries to chain -> save chain resource
Only when the subaccount nonce is incorrect, we should start to use UpdateSubaccountNonceFromChain