### PR TITLE
fix: add cancel context to stop blockHeight fetcher

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -457,7 +457,9 @@ func (c *chainClient) Close() {
 		close(c.msgC)
 	}
 
-	c.cancelFn()
+	if c.cancelFn != nil {
+		c.cancelFn()
+	}
 	<-c.doneC
 	if c.conn != nil {
 		c.conn.Close()

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -143,6 +143,9 @@ type chainClient struct {
 	msgC        chan sdk.Msg
 	syncMux     *sync.Mutex
 
+	cancelCtx context.Context
+	cancelFn  func()
+
 	accNum    uint64
 	accSeq    uint64
 	gasWanted uint64
@@ -208,6 +211,7 @@ func NewChainClient(
 		}
 	}
 
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
 	// build client
 	cc := &chainClient{
 		ctx:  ctx,
@@ -224,6 +228,8 @@ func NewChainClient(
 		syncMux:   new(sync.Mutex),
 		msgC:      make(chan sdk.Msg, msgCommitBatchSizeLimit),
 		doneC:     make(chan bool, 1),
+		cancelCtx: cancelCtx,
+		cancelFn:  cancelFn,
 
 		sessionEnabled: stickySessionEnabled,
 
@@ -280,15 +286,23 @@ func (c *chainClient) syncNonce() {
 }
 
 func (c *chainClient) syncTimeoutHeight() {
+	t := time.NewTicker(defaultTimeoutHeightSyncInterval)
+	defer t.Stop()
+
 	for {
-		ctx := context.Background()
-		block, err := c.ctx.Client.Block(ctx, nil)
+		block, err := c.ctx.Client.Block(c.cancelCtx, nil)
 		if err != nil {
 			c.logger.WithError(err).Errorln("failed to get current block")
 			return
 		}
 		c.txFactory.WithTimeoutHeight(uint64(block.Block.Height) + defaultTimeoutHeight)
-		time.Sleep(defaultTimeoutHeightSyncInterval)
+
+		select {
+		case <-c.cancelCtx.Done():
+			return
+		case <-t.C:
+			continue
+		}
 	}
 }
 
@@ -442,6 +456,8 @@ func (c *chainClient) Close() {
 	if atomic.CompareAndSwapInt64(&c.closed, 0, 1) {
 		close(c.msgC)
 	}
+
+	c.cancelFn()
 	<-c.doneC
 	if c.conn != nil {
 		c.conn.Close()


### PR DESCRIPTION
# Context

- The goroutine `syncTimeoutHeight` can't be canceled right away when client.Close() called -> the routine stuck there forever -> goroutine leak -> not good in sdk users app when they create cancel() multiple times (not likely, but may happen when they try create internal server to use multiple accounts)

# Changes

- Add cancelable context to stop polling syncTimeOutHeight (it can stop both Block() call and the routine)
- Add time.Ticker to enable sleeping with cancel ability

# Test

Now it can sync block and cancel normally when client.Close() called

<img width="946" alt="image" src="https://user-images.githubusercontent.com/30641530/234738849-2efa3747-8ed3-4d8d-8bfd-2931b62f9abd.png">
