### PR TITLE
fix/solve memory leak issue

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -272,7 +272,7 @@ func NewChainClient(
 	}
 
 	// create file if not exist
-	_, err = os.OpenFile(defaultChainCookieName, os.O_RDONLY|os.O_CREATE, 0666)
+	cookie_file, err := os.OpenFile(defaultChainCookieName, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		cc.logger.Errorln(err)
 	}

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -272,7 +272,11 @@ func NewChainClient(
 	}
 
 	// create file if not exist
-	os.OpenFile(defaultChainCookieName, os.O_RDONLY|os.O_CREATE, 0666)
+	_, err = os.OpenFile(defaultChainCookieName, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		cc.logger.Errorln(err)
+	}
+	defer cookie_file.Close()
 
 	// attempt to load from disk
 	data, err := os.ReadFile(defaultChainCookieName)
@@ -479,6 +483,10 @@ func (c *chainClient) Close() {
 	<-c.doneC
 	if c.conn != nil {
 		c.conn.Close()
+	}
+
+	if c.cometbftClient != nil {
+		c.cometbftClient.Stop()
 	}
 }
 


### PR DESCRIPTION
- Ensure the cookie file is closed.
- Ensure Comet BFT connection in the client is stopped when the client is closed