### PR TITLE
Fix amino for tokenfactory

### DIFF
--- a/chain/tokenfactory/types/codec.go
+++ b/chain/tokenfactory/types/codec.go
@@ -37,7 +37,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 
 var (
 	amino     = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	ModuleCdc = codec.NewAminoCodec(amino)
 )
 
 func init() {


### PR DESCRIPTION
Thank guys from qwerty-exchange. We add this in order to support messages on FE that used legacy amino cdc