### PR TITLE
feat(chain-client) allows to customize the txFactory as an option

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -190,9 +190,14 @@ func NewChainClient(
 	}
 
 	// init tx factory
-	txFactory := NewTxFactory(ctx)
-	if len(opts.GasPrices) > 0 {
-		txFactory = txFactory.WithGasPrices(opts.GasPrices)
+	var txFactory tx.Factory
+	if opts.TxFactory == nil {
+		txFactory = NewTxFactory(ctx)
+		if len(opts.GasPrices) > 0 {
+			txFactory = txFactory.WithGasPrices(opts.GasPrices)
+		}
+	} else {
+		txFactory = *opts.TxFactory
 	}
 
 	// init grpc connection

--- a/client/common/options.go
+++ b/client/common/options.go
@@ -3,6 +3,7 @@ package common
 import (
 	ctypes "github.com/InjectiveLabs/sdk-go/chain/types"
 	log "github.com/InjectiveLabs/suplog"
+	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
@@ -20,6 +21,7 @@ func init() {
 type ClientOptions struct {
 	GasPrices string
 	TLSCert   credentials.TransportCredentials
+	TxFactory *tx.Factory
 }
 
 type ClientOption func(opts *ClientOptions) error
@@ -49,6 +51,13 @@ func OptionTLSCert(tlsCert credentials.TransportCredentials) ClientOption {
 			log.Infoln("succesfully load server TLS cert")
 		}
 		opts.TLSCert = tlsCert
+		return nil
+	}
+}
+
+func OptionTxFactory(txFactory *tx.Factory) ClientOption {
+	return func(opts *ClientOptions) error {
+		opts.TxFactory = txFactory
 		return nil
 	}
 }

--- a/examples/chain/20_MsgExec/example.go
+++ b/examples/chain/20_MsgExec/example.go
@@ -64,11 +64,13 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
+	txFactory := chainclient.NewTxFactory(clientCtx)
+	txFactory = txFactory.WithGasPrices("500000000inj")
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network.ChainGrpcEndpoint,
 		common.OptionTLSCert(network.ChainTlsCert),
-		common.OptionGasPrices("500000000inj"),
+		common.OptionTxFactory(&txFactory),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Adds a new option to allow using a custom tx factory in when using the default chain client constructor.

See the example on how to use it to overseed `common.OptionGasPrices` and customize the factory.