### PR TITLE
feat/order_hash_generation_for_multi_subaccount

### DIFF
--- a/client/chain/chain_test.go
+++ b/client/chain/chain_test.go
@@ -1,0 +1,104 @@
+package chain
+
+import (
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cosmtypes "github.com/cosmos/cosmos-sdk/types"
+	eth "github.com/ethereum/go-ethereum/common"
+	"os"
+	"testing"
+)
+
+func accountForTests() (cosmtypes.AccAddress, keyring.Keyring, error) {
+	senderAddress, cosmosKeyring, err := InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	return senderAddress, cosmosKeyring, err
+}
+
+func createClient(senderAddress cosmtypes.AccAddress, cosmosKeyring keyring.Keyring, network common.Network) (ChainClient, error) {
+	tmClient, _ := rpchttp.New(network.TmEndpoint, "/websocket")
+	clientCtx, err := NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	chainClient, err := NewChainClient(
+		clientCtx,
+		network.ChainGrpcEndpoint,
+		common.OptionTLSCert(network.ChainTlsCert),
+		common.OptionGasPrices("500000000inj"),
+	)
+
+	return chainClient, err
+}
+
+func TestDefaultSubaccount(t *testing.T) {
+	network := common.LoadNetwork("testnet", "k8s")
+	senderAddress, cosmosKeyring, err := accountForTests()
+
+	if err != nil {
+		t.Errorf("Error creating the address %v", err)
+	}
+
+	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
+
+	if err != nil {
+		t.Errorf("Error creating the client %v", err)
+	}
+
+	defaultSubaccountID := chainClient.DefaultSubaccount(senderAddress)
+
+	expectedSubaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+	expectedSubaccountIdHash := eth.HexToHash(expectedSubaccountId)
+	if defaultSubaccountID != expectedSubaccountIdHash {
+		t.Error("The default subaccount is calculated incorrectly")
+	}
+}
+
+func TestGetSubaccountWithIndes(t *testing.T) {
+	network := common.LoadNetwork("testnet", "k8s")
+	senderAddress, cosmosKeyring, err := accountForTests()
+
+	if err != nil {
+		t.Errorf("Error creating the address %v", err)
+	}
+
+	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
+
+	if err != nil {
+		t.Errorf("Error creating the client %v", err)
+	}
+
+	subaccountOne := chainClient.Subaccount(senderAddress, 1)
+	subaccountThirty := chainClient.Subaccount(senderAddress, 30)
+
+	expectedSubaccounOnetId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000001"
+	expectedSubaccountOneIdHash := eth.HexToHash(expectedSubaccounOnetId)
+
+	expectedSubaccounThirtytId := "0xaf79152ac5df276d9a8e1e2e22822f971347490200000000000000000000001e"
+	expectedSubaccountThirtyIdHash := eth.HexToHash(expectedSubaccounThirtytId)
+
+	if subaccountOne != expectedSubaccountOneIdHash {
+		t.Error("The subaccount with index 1 was calculated incorrectly")
+	}
+	if subaccountThirty != expectedSubaccountThirtyIdHash {
+		t.Error("The subaccount with index 30 was calculated incorrectly")
+	}
+
+}

--- a/client/chain/orderhash.go
+++ b/client/chain/orderhash.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"golang.org/x/exp/maps"
 	"strconv"
 
 	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
@@ -59,7 +58,7 @@ var domain = gethsigner.TypedDataDomain{
 }
 
 func (c *chainClient) UpdateSubaccountNonceFromChain() error {
-	for _, subaccountId := range maps.Keys(c.subaccountToNonce) {
+	for subaccountId := range c.subaccountToNonce {
 		err := c.SynchronizeSubaccountNonce(subaccountId)
 		if err != nil {
 			return err

--- a/examples/chain/0_LocalOrderHash/example.go
+++ b/examples/chain/0_LocalOrderHash/example.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	// prepare tx msg
-	defaultSubaccountID := chainClient.DefaultSubaccount(senderAddress)
+	defaultSubaccountID := chainClient.Subaccount(senderAddress, 1)
 
 	spotOrder := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
 		OrderType:    exchangetypes.OrderType_BUY,
@@ -87,7 +87,7 @@ func main() {
 	msg1.Orders = []exchangetypes.DerivativeOrder{*derivativeOrder, *derivativeOrder}
 
 	// compute local order hashes
-	orderHashes, err := chainClient.ComputeOrderHashes(msg.Orders, msg1.Orders)
+	orderHashes, err := chainClient.ComputeOrderHashes(msg.Orders, msg1.Orders, defaultSubaccountID)
 
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
- Added logic to allow ChainClient to generate the subaccountId for any subaccount index.
- Improved the order hash calculator to allow using any subaccountId instead of only the default subaccount