### PR TITLE
feat/refactor_cookies_management

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -19,7 +18,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	log "github.com/InjectiveLabs/suplog"
-	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -132,7 +130,9 @@ type ChainClient interface {
 	GetGasFee() (string, error)
 
 	StreamEventOrderFail(sender string, failEventCh chan map[string]uint)
+	StreamEventOrderFailWithWebsocket(sender string, websocket *rpchttp.HTTP, failEventCh chan map[string]uint)
 	StreamOrderbookUpdateEvents(orderbookType OrderbookType, marketIds []string, orderbookCh chan exchangetypes.Orderbook)
+	StreamOrderbookUpdateEventsWithWebsocket(orderbookType OrderbookType, marketIds []string, websocket *rpchttp.HTTP, orderbookCh chan exchangetypes.Orderbook)
 
 	// get tx from chain node
 	GetTx(ctx context.Context, txHash string) (*txtypes.GetTxResponse, error)
@@ -141,6 +141,7 @@ type ChainClient interface {
 
 type chainClient struct {
 	ctx       client.Context
+	network   common.Network
 	opts      *common.ClientOptions
 	logger    log.Logger
 	conn      *grpc.ClientConn
@@ -162,7 +163,6 @@ type chainClient struct {
 	sessionCookie  string
 	sessionEnabled bool
 
-	cometbftClient      rpcclient.Client
 	txClient            txtypes.ServiceClient
 	authQueryClient     authtypes.QueryClient
 	exchangeQueryClient exchangetypes.QueryClient
@@ -175,15 +175,19 @@ type chainClient struct {
 	canSign bool
 }
 
-// NewCosmosClient creates a new gRPC client that communicates with gRPC server at protoAddr.
+// NewChainClient creates a new gRPC client that communicates with gRPC server at protoAddr.
 // protoAddr must be in form "tcp://127.0.0.1:8080" or "unix:///tmp/test.sock", protocol is required.
 func NewChainClient(
 	ctx client.Context,
-	protoAddr string,
+	network common.Network,
 	options ...common.ClientOption,
 ) (ChainClient, error) {
 	// process options
 	opts := common.DefaultClientOptions()
+
+	if network.ChainTlsCert != nil {
+		options = append(options, common.OptionTLSCert(network.ChainTlsCert))
+	}
 	for _, opt := range options {
 		if err := opt(opts); err != nil {
 			err = errors.Wrap(err, "error in client option")
@@ -207,37 +211,22 @@ func NewChainClient(
 	var err error
 	stickySessionEnabled := true
 	if opts.TLSCert != nil {
-		conn, err = grpc.Dial(protoAddr, grpc.WithTransportCredentials(opts.TLSCert), grpc.WithContextDialer(common.DialerFunc))
+		conn, err = grpc.Dial(network.ChainGrpcEndpoint, grpc.WithTransportCredentials(opts.TLSCert), grpc.WithContextDialer(common.DialerFunc))
 	} else {
-		conn, err = grpc.Dial(protoAddr, grpc.WithInsecure(), grpc.WithContextDialer(common.DialerFunc))
+		conn, err = grpc.Dial(network.ChainGrpcEndpoint, grpc.WithInsecure(), grpc.WithContextDialer(common.DialerFunc))
 		stickySessionEnabled = false
 	}
 	if err != nil {
-		err = errors.Wrapf(err, "failed to connect to the gRPC: %s", protoAddr)
+		err = errors.Wrapf(err, "failed to connect to the gRPC: %s", network.ChainGrpcEndpoint)
 		return nil, err
-	}
-
-	// init tm websocket
-	var cometbftClient *rpchttp.HTTP
-	if ctx.NodeURI != "" {
-		cometbftClient, err = rpchttp.New(ctx.NodeURI, "/websocket")
-		if err != nil {
-			panic(err)
-		}
-
-		if !cometbftClient.IsRunning() {
-			err = cometbftClient.Start()
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	cancelCtx, cancelFn := context.WithCancel(context.Background())
 	// build client
 	cc := &chainClient{
-		ctx:  ctx,
-		opts: opts,
+		ctx:     ctx,
+		network: network,
+		opts:    opts,
 
 		logger: log.WithFields(log.Fields{
 			"module": "sdk-go",
@@ -255,7 +244,6 @@ func NewChainClient(
 
 		sessionEnabled: stickySessionEnabled,
 
-		cometbftClient:      cometbftClient,
 		txClient:            txtypes.NewServiceClient(conn),
 		authQueryClient:     authtypes.NewQueryClient(conn),
 		exchangeQueryClient: exchangetypes.NewQueryClient(conn),
@@ -371,92 +359,16 @@ func (c *chainClient) getAccSeq() uint64 {
 	return c.accSeq
 }
 
-func (c *chainClient) setCookie(metadata metadata.MD) {
-	if !c.sessionEnabled {
-		return
-	}
-	md := metadata.Get("set-cookie")
-	if len(md) > 0 {
-		// write to client instance
-		c.sessionCookie = md[0]
-		// write to disk
-		err := os.WriteFile(defaultChainCookieName, []byte(md[0]), 0644)
-		if err != nil {
-			c.logger.Errorln(err)
-			return
-		}
-		c.logger.Infoln("chain session cookie saved to disk")
-	}
-}
-
-func (c *chainClient) fetchCookie(ctx context.Context) context.Context {
+func (c *chainClient) requestCookie() metadata.MD {
 	var header metadata.MD
 	c.txClient.GetTx(context.Background(), &txtypes.GetTxRequest{}, grpc.Header(&header))
-	c.setCookie(header)
-	time.Sleep(defaultBlockTime)
-
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs("cookie", c.sessionCookie))
-}
-
-func cookieByName(cookies []*http.Cookie, key string) *http.Cookie {
-	for _, c := range cookies {
-		if c.Name == key {
-			return c
-		}
-	}
-	return nil
-}
-
-func (c *chainClient) getCookieExpirationTime(cookies []*http.Cookie) (time.Time, error) {
-	var expiresAt string
-	if cookieByName(cookies, "GCLB") != nil {
-		// parse global load balance cookie timestamp
-		cookie := cookieByName(cookies, "expires")
-		expiresAt = strings.Replace(cookie.Value, "-", " ", -1)
-	} else {
-		cookie := cookieByName(cookies, "Expires")
-		if cookie == nil {
-			return time.Time{}, nil
-		}
-
-		expiresAt = strings.Replace(cookie.Value, "-", " ", -1)
-		yyyy := fmt.Sprintf("20%s", expiresAt[12:14])
-		expiresAt = expiresAt[:12] + yyyy + expiresAt[14:]
-	}
-
-	return time.Parse(time.RFC1123, expiresAt)
+	return header
 }
 
 func (c *chainClient) getCookie(ctx context.Context) context.Context {
-	md := metadata.Pairs("cookie", c.sessionCookie)
-	if !c.sessionEnabled {
-		return metadata.NewOutgoingContext(ctx, md)
-	}
-
-	// borrow http request to parse cookie
-	header := http.Header{}
-	header.Add("Cookie", c.sessionCookie)
-	request := http.Request{Header: header}
-	cookies := request.Cookies()
-
-	if len(cookies) > 0 {
-		// parse expire field into unix timestamp
-		expiresTimestamp, err := c.getCookieExpirationTime(cookies)
-		if err != nil {
-			panic(err)
-		}
-
-		if !expiresTimestamp.IsZero() {
-			// renew session if timestamp diff < offset
-			timestampDiff := expiresTimestamp.Unix() - time.Now().Unix()
-			if timestampDiff < defaultSessionRenewalOffset {
-				return c.fetchCookie(ctx)
-			}
-		}
-	} else {
-		return c.fetchCookie(ctx)
-	}
-
+	provider := common.NewMetadataProvider(c.requestCookie)
+	cookie, _ := c.network.ChainMetadata(provider)
+	md := metadata.Pairs("cookie", cookie)
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
@@ -498,10 +410,6 @@ func (c *chainClient) Close() {
 	<-c.doneC
 	if c.conn != nil {
 		c.conn.Close()
-	}
-
-	if c.cometbftClient != nil {
-		c.cometbftClient.Stop()
 	}
 }
 
@@ -580,8 +488,7 @@ func (c *chainClient) SimulateMsg(clientCtx client.Context, msgs ...sdk.Msg) (*t
 
 	ctx := context.Background()
 	ctx = c.getCookie(ctx)
-	var header metadata.MD
-	simRes, err := c.txClient.Simulate(ctx, &txtypes.SimulateRequest{TxBytes: simTxBytes}, grpc.Header(&header))
+	simRes, err := c.txClient.Simulate(ctx, &txtypes.SimulateRequest{TxBytes: simTxBytes})
 	if err != nil {
 		err = errors.Wrap(err, "failed to CalculateGas")
 		return nil, err
@@ -671,9 +578,8 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 	}
 
 	ctx := context.Background()
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.txClient.BroadcastTx(ctx, &req, grpc.Header(&header))
+	res, err := c.txClient.BroadcastTx(ctx, &req)
 	if err != nil {
 		return res, err
 	}
@@ -720,9 +626,8 @@ func (c *chainClient) AsyncBroadcastSignedTx(txBytes []byte) (*txtypes.Broadcast
 
 	ctx := context.Background()
 	// use our own client to broadcast tx
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.txClient.BroadcastTx(ctx, &req, grpc.Header(&header))
+	res, err := c.txClient.BroadcastTx(ctx, &req)
 	if err != nil {
 		return nil, err
 	}
@@ -749,8 +654,7 @@ func (c *chainClient) broadcastTx(
 			return nil, err
 		}
 		ctx := c.getCookie(ctx)
-		var header metadata.MD
-		simRes, err := c.txClient.Simulate(ctx, &txtypes.SimulateRequest{TxBytes: simTxBytes}, grpc.Header(&header))
+		simRes, err := c.txClient.Simulate(ctx, &txtypes.SimulateRequest{TxBytes: simTxBytes})
 		if err != nil {
 			err = errors.Wrap(err, "failed to CalculateGas")
 			return nil, err
@@ -787,9 +691,8 @@ func (c *chainClient) broadcastTx(
 		Mode:    txtypes.BroadcastMode_BROADCAST_MODE_SYNC,
 	}
 	// use our own client to broadcast tx
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.txClient.BroadcastTx(ctx, &req, grpc.Header(&header))
+	res, err := c.txClient.BroadcastTx(ctx, &req)
 	if !await || err != nil {
 		return res, err
 	}
@@ -1242,8 +1145,28 @@ func (c *chainClient) BuildExchangeBatchUpdateOrdersAuthz(
 }
 
 func (c *chainClient) StreamEventOrderFail(sender string, failEventCh chan map[string]uint) {
+	var cometbftClient *rpchttp.HTTP
+	var err error
+
+	cometbftClient, err = rpchttp.New(c.network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	if !cometbftClient.IsRunning() {
+		err = cometbftClient.Start()
+		if err != nil {
+			panic(err)
+		}
+	}
+	defer cometbftClient.Stop()
+
+	c.StreamEventOrderFailWithWebsocket(sender, cometbftClient, failEventCh)
+}
+
+func (c *chainClient) StreamEventOrderFailWithWebsocket(sender string, websocket *rpchttp.HTTP, failEventCh chan map[string]uint) {
 	filter := fmt.Sprintf("tm.event='Tx' AND message.sender='%s' AND message.action='/injective.exchange.v1beta1.MsgBatchUpdateOrders' AND injective.exchange.v1beta1.EventOrderFail.flags EXISTS", sender)
-	eventCh, err := c.cometbftClient.Subscribe(context.Background(), "OrderFail", filter, 10000)
+	eventCh, err := websocket.Subscribe(context.Background(), "OrderFail", filter, 10000)
 	if err != nil {
 		panic(err)
 	}
@@ -1276,8 +1199,29 @@ func (c *chainClient) StreamEventOrderFail(sender string, failEventCh chan map[s
 }
 
 func (c *chainClient) StreamOrderbookUpdateEvents(orderbookType OrderbookType, marketIds []string, orderbookCh chan exchangetypes.Orderbook) {
+	var cometbftClient *rpchttp.HTTP
+	var err error
+
+	cometbftClient, err = rpchttp.New(c.network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	if !cometbftClient.IsRunning() {
+		err = cometbftClient.Start()
+		if err != nil {
+			panic(err)
+		}
+	}
+	defer cometbftClient.Stop()
+
+	c.StreamOrderbookUpdateEventsWithWebsocket(orderbookType, marketIds, cometbftClient, orderbookCh)
+
+}
+
+func (c *chainClient) StreamOrderbookUpdateEventsWithWebsocket(orderbookType OrderbookType, marketIds []string, websocket *rpchttp.HTTP, orderbookCh chan exchangetypes.Orderbook) {
 	filter := fmt.Sprintf("tm.event='NewBlock' AND %s EXISTS", orderbookType)
-	eventCh, err := c.cometbftClient.Subscribe(context.Background(), "OrderbookUpdate", filter, 10000)
+	eventCh, err := websocket.Subscribe(context.Background(), "OrderbookUpdate", filter, 10000)
 	if err != nil {
 		panic(err)
 	}

--- a/client/chain/chain_test.go
+++ b/client/chain/chain_test.go
@@ -40,8 +40,7 @@ func createClient(senderAddress cosmtypes.AccAddress, cosmosKeyring keyring.Keyr
 
 	chainClient, err := NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 
@@ -49,7 +48,7 @@ func createClient(senderAddress cosmtypes.AccAddress, cosmosKeyring keyring.Keyr
 }
 
 func TestDefaultSubaccount(t *testing.T) {
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	senderAddress, cosmosKeyring, err := accountForTests()
 
 	if err != nil {
@@ -71,8 +70,8 @@ func TestDefaultSubaccount(t *testing.T) {
 	}
 }
 
-func TestGetSubaccountWithIndes(t *testing.T) {
-	network := common.LoadNetwork("testnet", "k8s")
+func TestGetSubaccountWithIndex(t *testing.T) {
+	network := common.LoadNetwork("testnet", "lb")
 	senderAddress, cosmosKeyring, err := accountForTests()
 
 	if err != nil {

--- a/client/common/network.go
+++ b/client/common/network.go
@@ -4,26 +4,174 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"google.golang.org/grpc/metadata"
 	"net"
+	"net/http"
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/credentials"
 )
 
+const (
+	SessionRenewalOffset = 2 * time.Minute
+)
+
+func cookieByName(cookies []*http.Cookie, key string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == key {
+			return c
+		}
+	}
+	return nil
+}
+
+type MetadataProvider struct {
+	f func() metadata.MD
+}
+
+func NewMetadataProvider(f func() metadata.MD) MetadataProvider {
+	return MetadataProvider{f: f}
+}
+
+func (provider *MetadataProvider) metadata() metadata.MD {
+	return provider.f()
+}
+
+type CookieAssistant interface {
+	Metadata(provider MetadataProvider) (string, error)
+}
+
+type ExpiringCookieAssistant struct {
+	expirationKey string
+	timeLayout    string
+	cookie        string
+}
+
+func (assistant *ExpiringCookieAssistant) initializeCookie(provider MetadataProvider) error {
+	md := provider.metadata()
+	cookieInfo := md.Get("set-cookie")
+
+	if len(cookieInfo) == 0 {
+		return fmt.Errorf("error getting a new cookie from the server")
+	}
+
+	assistant.cookie = cookieInfo[0]
+	return nil
+}
+
+func (assistant *ExpiringCookieAssistant) checkCookieExpiration() {
+	//borrow http request to parse cookie
+	header := http.Header{}
+	header.Add("Cookie", assistant.cookie)
+	request := http.Request{Header: header}
+	cookies := request.Cookies()
+	cookie := cookieByName(cookies, assistant.expirationKey)
+
+	if cookie != nil {
+		expirationTime, err := time.Parse(assistant.timeLayout, cookie.Value)
+
+		if err == nil {
+			timestampDiff := expirationTime.Sub(time.Now())
+			if timestampDiff < SessionRenewalOffset {
+				assistant.cookie = ""
+			}
+		}
+	}
+}
+
+func (assistant *ExpiringCookieAssistant) Metadata(provider MetadataProvider) (string, error) {
+	if assistant.cookie == "" {
+		err := assistant.initializeCookie(provider)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	cookie := assistant.cookie
+	assistant.checkCookieExpiration()
+
+	return cookie, nil
+}
+
+func TestnetKubernetesCookieAssistant() ExpiringCookieAssistant {
+	assistant := ExpiringCookieAssistant{}
+	assistant.expirationKey = "Expires"
+	assistant.timeLayout = "Mon, 02-Jan-06 15:04:05 MST"
+
+	return assistant
+}
+
+func MainnetKubernetesCookieAssistant() ExpiringCookieAssistant {
+	assistant := ExpiringCookieAssistant{}
+	assistant.expirationKey = "expires"
+	assistant.timeLayout = "Mon, 02-Jan-2006 15:04:05 MST"
+
+	return assistant
+}
+
+type BareMetalLoadBalancedCookieAssistant struct {
+	cookie string
+}
+
+func (assistant *BareMetalLoadBalancedCookieAssistant) initializeCookie(provider MetadataProvider) error {
+	md := provider.metadata()
+	cookieInfo := md.Get("set-cookie")
+
+	if len(cookieInfo) == 0 {
+		return fmt.Errorf("error getting a new cookie from the server")
+	}
+
+	assistant.cookie = cookieInfo[0]
+	return nil
+}
+
+func (assistant *BareMetalLoadBalancedCookieAssistant) Metadata(provider MetadataProvider) (string, error) {
+	if assistant.cookie == "" {
+		err := assistant.initializeCookie(provider)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return assistant.cookie, nil
+}
+
+type DisabledCookieAssistant struct{}
+
+func (assistant *DisabledCookieAssistant) Metadata(provider MetadataProvider) (string, error) {
+	return "", nil
+}
+
 type Network struct {
-	LcdEndpoint          string
-	TmEndpoint           string
-	ChainGrpcEndpoint    string
-	ChainTlsCert         credentials.TransportCredentials
-	ExchangeGrpcEndpoint string
-	ExplorerGrpcEndpoint string
-	ExchangeTlsCert      credentials.TransportCredentials
-	ExplorerTlsCert      credentials.TransportCredentials
-	ChainId              string
-	Fee_denom            string
-	Name                 string
+	LcdEndpoint             string
+	TmEndpoint              string
+	ChainGrpcEndpoint       string
+	ChainTlsCert            credentials.TransportCredentials
+	ExchangeGrpcEndpoint    string
+	ExplorerGrpcEndpoint    string
+	ExchangeTlsCert         credentials.TransportCredentials
+	ExplorerTlsCert         credentials.TransportCredentials
+	ChainId                 string
+	Fee_denom               string
+	Name                    string
+	chainCookieAssistant    CookieAssistant
+	exchangeCookieAssistant CookieAssistant
+	explorerCookieAssistant CookieAssistant
+}
+
+func (network *Network) ChainMetadata(provider MetadataProvider) (string, error) {
+	return network.chainCookieAssistant.Metadata(provider)
+}
+
+func (network *Network) ExchangeMetadata(provider MetadataProvider) (string, error) {
+	return network.exchangeCookieAssistant.Metadata(provider)
+}
+
+func (network *Network) ExplorerMetadata(provider MetadataProvider) (string, error) {
+	return network.explorerCookieAssistant.Metadata(provider)
 }
 
 func getFileAbsPath(relativePath string) string {
@@ -36,101 +184,144 @@ func LoadNetwork(name string, node string) Network {
 
 	case "devnet-1":
 		return Network{
-			LcdEndpoint:          "https://devnet-1.lcd.injective.dev",
-			TmEndpoint:           "https://devnet-1.tm.injective.dev:443",
-			ChainGrpcEndpoint:    "tcp://devnet-1.grpc.injective.dev:9900",
-			ExchangeGrpcEndpoint: "tcp://devnet-1.api.injective.dev:9910",
-			ExplorerGrpcEndpoint: "tcp://devnet-1.api.injective.dev:9911",
-			ChainId:              "injective-777",
-			Fee_denom:            "inj",
-			Name:                 "devnet-1",
+			LcdEndpoint:             "https://devnet-1.lcd.injective.dev",
+			TmEndpoint:              "https://devnet-1.tm.injective.dev:443",
+			ChainGrpcEndpoint:       "tcp://devnet-1.grpc.injective.dev:9900",
+			ExchangeGrpcEndpoint:    "tcp://devnet-1.api.injective.dev:9910",
+			ExplorerGrpcEndpoint:    "tcp://devnet-1.api.injective.dev:9911",
+			ChainId:                 "injective-777",
+			Fee_denom:               "inj",
+			Name:                    "devnet-1",
+			chainCookieAssistant:    &DisabledCookieAssistant{},
+			exchangeCookieAssistant: &DisabledCookieAssistant{},
+			explorerCookieAssistant: &DisabledCookieAssistant{},
 		}
 	case "devnet":
 		return Network{
-			LcdEndpoint:          "https://devnet.lcd.injective.dev",
-			TmEndpoint:           "https://devnet.tm.injective.dev:443",
-			ChainGrpcEndpoint:    "tcp://devnet.injective.dev:9900",
-			ExchangeGrpcEndpoint: "tcp://devnet.injective.dev:9910",
-			ExplorerGrpcEndpoint: "tcp://devnet.api.injective.dev:9911",
-			ChainId:              "injective-777",
-			Fee_denom:            "inj",
-			Name:                 "devnet",
+			LcdEndpoint:             "https://devnet.lcd.injective.dev",
+			TmEndpoint:              "https://devnet.tm.injective.dev:443",
+			ChainGrpcEndpoint:       "tcp://devnet.injective.dev:9900",
+			ExchangeGrpcEndpoint:    "tcp://devnet.injective.dev:9910",
+			ExplorerGrpcEndpoint:    "tcp://devnet.api.injective.dev:9911",
+			ChainId:                 "injective-777",
+			Fee_denom:               "inj",
+			Name:                    "devnet",
+			chainCookieAssistant:    &DisabledCookieAssistant{},
+			exchangeCookieAssistant: &DisabledCookieAssistant{},
+			explorerCookieAssistant: &DisabledCookieAssistant{},
 		}
 	case "testnet":
-		validNodes := []string{"sentry0", "sentry1", "k8s"}
+		validNodes := []string{"lb", "lb_k8s", "sentry", "sentry0", "sentry1"}
 		if !contains(validNodes, node) {
 			panic(fmt.Sprintf("invalid node %s for %s", node, name))
 		}
 
 		var lcdEndpoint, tmEndpoint, chainGrpcEndpoint, exchangeGrpcEndpoint, explorerGrpcEndpoint string
 		var chainTlsCert, exchangeTlsCert, explorerTlsCert credentials.TransportCredentials
-		if node == "k8s" {
+		var chainCookieAssistant, exchangeCookieAssistant, explorerCookieAssistant CookieAssistant
+		if node == "lb" {
+			lcdEndpoint = "https://testnet.sentry.lcd.injective.network:443"
+			tmEndpoint = "https://testnet.sentry.tm.injective.network:443"
+			chainGrpcEndpoint = "testnet.sentry.chain.grpc.injective.network:443"
+			exchangeGrpcEndpoint = "testnet.sentry.exchange.grpc.injective.network:443"
+			explorerGrpcEndpoint = "testnet.sentry.explorer.grpc.injective.network:443"
+			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			chainCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+			exchangeCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+			explorerCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+		} else if node == "lb_k8s" {
 			certPath := getFileAbsPath("../cert/testnet.crt")
 			lcdEndpoint = "https://k8s.testnet.lcd.injective.network"
 			tmEndpoint = "https://k8s.testnet.tm.injective.network:443"
 			chainGrpcEndpoint = "tcp://k8s.testnet.chain.grpc.injective.network:443"
-			chainTlsCert = LoadTlsCert(certPath, chainGrpcEndpoint)
 			exchangeGrpcEndpoint = "tcp://k8s.testnet.exchange.grpc.injective.network:443"
 			explorerGrpcEndpoint = "tcp://k8s.testnet.explorer.grpc.injective.network:443"
+			chainTlsCert = LoadTlsCert(certPath, chainGrpcEndpoint)
 			exchangeTlsCert = LoadTlsCert(certPath, exchangeGrpcEndpoint)
 			explorerTlsCert = LoadTlsCert(certPath, explorerGrpcEndpoint)
+			chainAssistant := TestnetKubernetesCookieAssistant()
+			chainCookieAssistant = &chainAssistant
+			exchangeAssistant := TestnetKubernetesCookieAssistant()
+			exchangeCookieAssistant = &exchangeAssistant
+			explorerAssistant := TestnetKubernetesCookieAssistant()
+			explorerCookieAssistant = &explorerAssistant
+		} else if node == "sentry" {
+			lcdEndpoint = "https://testnet.lcd.injective.network"
+			tmEndpoint = "https://testnet.tm.injective.network"
+			chainGrpcEndpoint = "testnet.chain.grpc.injective.network"
+			exchangeGrpcEndpoint = "testnet.exchange.grpc.injective.network"
+			explorerGrpcEndpoint = "testnet.explorer.grpc.injective.network"
+			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			chainCookieAssistant = &DisabledCookieAssistant{}
+			exchangeCookieAssistant = &DisabledCookieAssistant{}
+			explorerCookieAssistant = &DisabledCookieAssistant{}
 		} else {
 			lcdEndpoint = fmt.Sprintf("http://%s.injective.dev:10337", node)
 			tmEndpoint = fmt.Sprintf("http://%s.injective.dev:26657", node)
 			chainGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.dev:9900", node)
 			exchangeGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.dev:9910", node)
 			explorerGrpcEndpoint = "tcp://testnet.api.injective.dev:9911"
+			chainCookieAssistant = &DisabledCookieAssistant{}
+			exchangeCookieAssistant = &DisabledCookieAssistant{}
+			explorerCookieAssistant = &DisabledCookieAssistant{}
 		}
 
 		return Network{
-			LcdEndpoint:          lcdEndpoint,
-			TmEndpoint:           tmEndpoint,
-			ChainGrpcEndpoint:    chainGrpcEndpoint,
-			ChainTlsCert:         chainTlsCert,
-			ExchangeGrpcEndpoint: exchangeGrpcEndpoint,
-			ExchangeTlsCert:      exchangeTlsCert,
-			ExplorerGrpcEndpoint: explorerGrpcEndpoint,
-			ExplorerTlsCert:      explorerTlsCert,
-			ChainId:              "injective-888",
-			Fee_denom:            "inj",
-			Name:                 "testnet",
+			LcdEndpoint:             lcdEndpoint,
+			TmEndpoint:              tmEndpoint,
+			ChainGrpcEndpoint:       chainGrpcEndpoint,
+			ChainTlsCert:            chainTlsCert,
+			ExchangeGrpcEndpoint:    exchangeGrpcEndpoint,
+			ExchangeTlsCert:         exchangeTlsCert,
+			ExplorerGrpcEndpoint:    explorerGrpcEndpoint,
+			ExplorerTlsCert:         explorerTlsCert,
+			ChainId:                 "injective-888",
+			Fee_denom:               "inj",
+			Name:                    "testnet",
+			chainCookieAssistant:    chainCookieAssistant,
+			exchangeCookieAssistant: exchangeCookieAssistant,
+			explorerCookieAssistant: explorerCookieAssistant,
 		}
 	case "mainnet":
-		validNodes := []string{"k8s", "lb", "sentry", "sentry0", "sentry1", "sentry2", "sentry3"}
+		validNodes := []string{"lb", "lb_k8s", "sentry0", "sentry1", "sentry2", "sentry3"}
 		if !contains(validNodes, node) {
 			panic(fmt.Sprintf("invalid node %s for %s", node, name))
 		}
 		var lcdEndpoint, tmEndpoint, chainGrpcEndpoint, exchangeGrpcEndpoint, explorerGrpcEndpoint string
 		var chainTlsCert, exchangeTlsCert, explorerTlsCert credentials.TransportCredentials
-		if node == "k8s" {
-			certPath := getFileAbsPath("../cert/mainnet.crt")
-			lcdEndpoint = fmt.Sprintf("https://%s.mainnet.lcd.injective.network", node)
-			tmEndpoint = fmt.Sprintf("https://%s.mainnet.tm.injective.network:443", node)
-			chainGrpcEndpoint = fmt.Sprintf("tcp://%s.mainnet.chain.grpc.injective.network:443", node)
-			chainTlsCert = LoadTlsCert(certPath, chainGrpcEndpoint)
-			exchangeGrpcEndpoint = fmt.Sprintf("tcp://%s.mainnet.exchange.grpc.injective.network:443", node)
-			exchangeTlsCert = LoadTlsCert(certPath, exchangeGrpcEndpoint)
-			explorerGrpcEndpoint = "tcp://k8s.mainnet.explorer.grpc.injective.network:443"
-			explorerTlsCert = LoadTlsCert(certPath, explorerGrpcEndpoint)
-		} else if node == "lb" {
-			certPath := getFileAbsPath("../cert/mainnet.crt")
+		var chainCookieAssistant, exchangeCookieAssistant, explorerCookieAssistant CookieAssistant
+		if node == "lb" {
+			lcdEndpoint = "https://sentry.lcd.injective.network"
+			tmEndpoint = "https://sentry.tm.injective.network:443"
+			chainGrpcEndpoint = "sentry.chain.grpc.injective.network:443"
+			exchangeGrpcEndpoint = "sentry.exchange.grpc.injective.network:443"
+			explorerGrpcEndpoint = "sentry.explorer.grpc.injective.network:443"
+			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			chainCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+			exchangeCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+			explorerCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
+		} else if node == "lb_k8s" {
+			//certPath := getFileAbsPath("../cert/mainnet.crt")
 			lcdEndpoint = "https://k8s.global.mainnet.lcd.injective.network"
 			tmEndpoint = "https://k8s.global.mainnet.tm.injective.network:443"
 			chainGrpcEndpoint = "k8s.global.mainnet.chain.grpc.injective.network:443"
 			exchangeGrpcEndpoint = "k8s.global.mainnet.exchange.grpc.injective.network:443"
-			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
-			explorerGrpcEndpoint = "tcp://k8s.mainnet.explorer.grpc.injective.network:443"
-			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
-			explorerTlsCert = LoadTlsCert(certPath, explorerGrpcEndpoint)
-		} else if node == "sentry" {
-			lcdEndpoint = "https://sentry.lcd.injective.network"
-			tmEndpoint = "http://sentry.tm.injective.network:26657"
-			chainGrpcEndpoint = "sentry.chain.grpc.injective.network:443"
-			exchangeGrpcEndpoint = "sentry.exchange.grpc.injective.network:443"
 			explorerGrpcEndpoint = "k8s.global.mainnet.explorer.grpc.injective.network:443"
-			chainTlsCert = credentials.NewTLS(&tls.Config{InsecureSkipVerify: false})
-			exchangeTlsCert = credentials.NewTLS(&tls.Config{InsecureSkipVerify: false})
+			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
 			explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
+			chainAssistant := MainnetKubernetesCookieAssistant()
+			chainCookieAssistant = &chainAssistant
+			exchangeAssistant := MainnetKubernetesCookieAssistant()
+			exchangeCookieAssistant = &exchangeAssistant
+			explorerAssistant := MainnetKubernetesCookieAssistant()
+			explorerCookieAssistant = &explorerAssistant
 		} else {
 			lcdEndpoint = fmt.Sprintf("http://%s.injective.network:10337", node)
 			tmEndpoint = fmt.Sprintf("http://%s.injective.network:26657", node)
@@ -143,20 +334,26 @@ func LoadNetwork(name string, node string) Network {
 				explorerGrpcEndpoint = "k8s.global.mainnet.explorer.grpc.injective.network:443"
 				explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
 			}
+			chainCookieAssistant = &DisabledCookieAssistant{}
+			exchangeCookieAssistant = &DisabledCookieAssistant{}
+			explorerCookieAssistant = &DisabledCookieAssistant{}
 		}
 
 		return Network{
-			LcdEndpoint:          lcdEndpoint,
-			TmEndpoint:           tmEndpoint,
-			ChainGrpcEndpoint:    chainGrpcEndpoint,
-			ChainTlsCert:         chainTlsCert,
-			ExchangeGrpcEndpoint: exchangeGrpcEndpoint,
-			ExchangeTlsCert:      exchangeTlsCert,
-			ExplorerGrpcEndpoint: explorerGrpcEndpoint,
-			ExplorerTlsCert:      explorerTlsCert,
-			ChainId:              "injective-1",
-			Fee_denom:            "inj",
-			Name:                 "mainnet",
+			LcdEndpoint:             lcdEndpoint,
+			TmEndpoint:              tmEndpoint,
+			ChainGrpcEndpoint:       chainGrpcEndpoint,
+			ChainTlsCert:            chainTlsCert,
+			ExchangeGrpcEndpoint:    exchangeGrpcEndpoint,
+			ExchangeTlsCert:         exchangeTlsCert,
+			ExplorerGrpcEndpoint:    explorerGrpcEndpoint,
+			ExplorerTlsCert:         explorerTlsCert,
+			ChainId:                 "injective-1",
+			Fee_denom:               "inj",
+			Name:                    "mainnet",
+			chainCookieAssistant:    chainCookieAssistant,
+			exchangeCookieAssistant: exchangeCookieAssistant,
+			explorerCookieAssistant: explorerCookieAssistant,
 		}
 	}
 

--- a/client/common/network.go
+++ b/client/common/network.go
@@ -233,7 +233,7 @@ func LoadNetwork(name string, node string) Network {
 			explorerCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
 		} else if node == "lb_k8s" {
 			certPath := getFileAbsPath("../cert/testnet.crt")
-			lcdEndpoint = "https://k8s.testnet.lcd.injective.network"
+			lcdEndpoint = "https://k8s.testnet.lcd.injective.network:443"
 			tmEndpoint = "https://k8s.testnet.tm.injective.network:443"
 			chainGrpcEndpoint = "tcp://k8s.testnet.chain.grpc.injective.network:443"
 			exchangeGrpcEndpoint = "tcp://k8s.testnet.exchange.grpc.injective.network:443"
@@ -248,11 +248,11 @@ func LoadNetwork(name string, node string) Network {
 			explorerAssistant := TestnetKubernetesCookieAssistant()
 			explorerCookieAssistant = &explorerAssistant
 		} else if node == "sentry" {
-			lcdEndpoint = "https://testnet.lcd.injective.network"
-			tmEndpoint = "https://testnet.tm.injective.network"
-			chainGrpcEndpoint = "testnet.chain.grpc.injective.network"
-			exchangeGrpcEndpoint = "testnet.exchange.grpc.injective.network"
-			explorerGrpcEndpoint = "testnet.explorer.grpc.injective.network"
+			lcdEndpoint = "https://testnet.lcd.injective.network:443"
+			tmEndpoint = "https://testnet.tm.injective.network:443"
+			chainGrpcEndpoint = "testnet.chain.grpc.injective.network:443"
+			exchangeGrpcEndpoint = "testnet.exchange.grpc.injective.network:443"
+			explorerGrpcEndpoint = "testnet.explorer.grpc.injective.network:443"
 			chainTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
 			exchangeTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
 			explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})

--- a/client/common/network_test.go
+++ b/client/common/network_test.go
@@ -1,0 +1,235 @@
+package common
+
+import (
+	"fmt"
+	"google.golang.org/grpc/metadata"
+	"testing"
+	"time"
+)
+
+func TestMainnetKubernetesLoadBalancedCookieAssistant(t *testing.T) {
+	assistant := MainnetKubernetesCookieAssistant()
+	expectedCookie := "GCLB=CMOO2-DdvKWMqQE; path=/; HttpOnly; expires=Sat, 16-Sep-2023 18:26:00 GMT"
+
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", expectedCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != expectedCookie {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+}
+
+func TestMainnetKubernetesLoadBalancedCookieAssistantRemovesExpiredCookie(t *testing.T) {
+	assistant := MainnetKubernetesCookieAssistant()
+	tt := time.Now()
+	closeExpirationTime := tt.Add(30 * time.Second)
+
+	soonToExpireCookie := fmt.Sprintf(
+		"GCLB=CMOO2-DdvKWMqQE; path=/; HttpOnly; expires=%s",
+		closeExpirationTime.Format("Mon, 02-Jan-2006 15:04:05 MST"),
+	)
+
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", soonToExpireCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != soonToExpireCookie {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+
+	nextExpirationTime := tt.Add(5 * time.Minute)
+	secondCookie := fmt.Sprintf(
+		"GCLB=CMOO2-DdvKWMqQE; path=/; HttpOnly; expires=%s",
+		nextExpirationTime.Format("Mon, 02-Jan-2006 15:04:05 MST"),
+	)
+
+	providerFunc = func() metadata.MD {
+		md := metadata.Pairs("set-cookie", secondCookie)
+		return md
+	}
+
+	provider = NewMetadataProvider(providerFunc)
+	cookie, err = assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != secondCookie {
+		t.Fatalf("The expired cookie was not removed")
+	}
+
+	farFutureTime := tt.Add(5 * time.Hour)
+	notRequiredCookie := fmt.Sprintf(
+		"GCLB=CMOO2-DdvKWMqQE; path=/; HttpOnly; expires=%s",
+		farFutureTime.Format("Mon, 02-Jan-2006 15:04:05 MST"),
+	)
+
+	providerFunc = func() metadata.MD {
+		md := metadata.Pairs("set-cookie", notRequiredCookie)
+		return md
+	}
+
+	provider = NewMetadataProvider(providerFunc)
+	cookie, err = assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != secondCookie {
+		t.Fatalf("The cookie assistant removed a cookie that was not expired")
+	}
+
+}
+
+func TestTestnetKubernetesLoadBalancedCookieAssistant(t *testing.T) {
+	assistant := TestnetKubernetesCookieAssistant()
+	expectedCookie := "grpc-cookie=d97c7a00bcb7bc8b69b26fb0303b60d4; Expires=Sun, 17-Sep-23 13:18:08 GMT; Max-Age=172800; Path=/; Secure; HttpOnly"
+
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", expectedCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != expectedCookie {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+}
+
+func TestTestnetKubernetesLoadBalancedCookieAssistantRemovesExpiredCookie(t *testing.T) {
+	assistant := TestnetKubernetesCookieAssistant()
+	tt := time.Now()
+	closeExpirationTime := tt.Add(30 * time.Second)
+
+	soonToExpireCookie := fmt.Sprintf(
+		"grpc-cookie=d97c7a00bcb7bc8b69b26fb0303b60d4; Expires=%s; Max-Age=172800; Path=/; Secure; HttpOnly",
+		closeExpirationTime.Format("Mon, 02-Jan-06 15:04:05 MST"),
+	)
+
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", soonToExpireCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != soonToExpireCookie {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+
+	nextExpirationTime := tt.Add(5 * time.Minute)
+	secondCookie := fmt.Sprintf(
+		"grpc-cookie=d97c7a00bcb7bc8b69b26fb0303b60d4; Expires=%s; Max-Age=172800; Path=/; Secure; HttpOnly",
+		nextExpirationTime.Format("Mon, 02-Jan-06 15:04:05 MST"),
+	)
+
+	providerFunc = func() metadata.MD {
+		md := metadata.Pairs("set-cookie", secondCookie)
+		return md
+	}
+
+	provider = NewMetadataProvider(providerFunc)
+	cookie, err = assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != secondCookie {
+		t.Fatalf("The expired cookie was not removed")
+	}
+
+	farFutureTime := tt.Add(5 * time.Hour)
+	notRequiredCookie := fmt.Sprintf(
+		"grpc-cookie=d97c7a00bcb7bc8b69b26fb0303b60d4; Expires=%s; Max-Age=172800; Path=/; Secure; HttpOnly",
+		farFutureTime.Format("Mon, 02-Jan-06 15:04:05 MST"),
+	)
+
+	providerFunc = func() metadata.MD {
+		md := metadata.Pairs("set-cookie", notRequiredCookie)
+		return md
+	}
+
+	provider = NewMetadataProvider(providerFunc)
+	cookie, err = assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != secondCookie {
+		t.Fatalf("The cookie assistant removed a cookie that was not expired")
+	}
+
+}
+
+func TestBareMetalLoadBalancedCookieAssistant(t *testing.T) {
+	assistant := BareMetalLoadBalancedCookieAssistant{}
+	expectedCookie := "lb=706c9476f31159d415afe3e9172972618b8ab99455c2daa799199540e6d31a1a; Path=/"
+
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", expectedCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != expectedCookie {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+}
+
+func TestDisabledCookieAssistant(t *testing.T) {
+	assistant := DisabledCookieAssistant{}
+	providedCookie := "lb=706c9476f31159d415afe3e9172972618b8ab99455c2daa799199540e6d31a1a; Path=/"
+	providerFunc := func() metadata.MD {
+		md := metadata.Pairs("set-cookie", providedCookie)
+		return md
+	}
+
+	provider := NewMetadataProvider(providerFunc)
+	cookie, err := assistant.Metadata(provider)
+
+	if err != nil {
+		t.Errorf("Error parsing the cookie string %v", err)
+	}
+
+	if cookie != "" {
+		t.Fatalf("The parsed cookie is different than the expected cookie")
+	}
+}

--- a/client/exchange/exchange.go
+++ b/client/exchange/exchange.go
@@ -3,7 +3,6 @@ package exchange
 import (
 	"context"
 	"fmt"
-
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	accountPB "github.com/InjectiveLabs/sdk-go/exchange/accounts_rpc/pb"
 	auctionPB "github.com/InjectiveLabs/sdk-go/exchange/auction_rpc/pb"
@@ -89,9 +88,12 @@ type ExchangeClient interface {
 	Close()
 }
 
-func NewExchangeClient(protoAddr string, options ...common.ClientOption) (ExchangeClient, error) {
+func NewExchangeClient(network common.Network, options ...common.ClientOption) (ExchangeClient, error) {
 	// process options
 	opts := common.DefaultClientOptions()
+	if network.ChainTlsCert != nil {
+		options = append(options, common.OptionTLSCert(network.ExchangeTlsCert))
+	}
 	for _, opt := range options {
 		if err := opt(opts); err != nil {
 			err = errors.Wrap(err, "error in client option")
@@ -103,20 +105,21 @@ func NewExchangeClient(protoAddr string, options ...common.ClientOption) (Exchan
 	var conn *grpc.ClientConn
 	var err error
 	if opts.TLSCert != nil {
-		conn, err = grpc.Dial(protoAddr, grpc.WithTransportCredentials(opts.TLSCert), grpc.WithContextDialer(common.DialerFunc))
+		conn, err = grpc.Dial(network.ExchangeGrpcEndpoint, grpc.WithTransportCredentials(opts.TLSCert), grpc.WithContextDialer(common.DialerFunc))
 	} else {
 
-		conn, err = grpc.Dial(protoAddr, grpc.WithInsecure(), grpc.WithContextDialer(common.DialerFunc))
+		conn, err = grpc.Dial(network.ExchangeGrpcEndpoint, grpc.WithInsecure(), grpc.WithContextDialer(common.DialerFunc))
 	}
 	if err != nil {
-		err := errors.Wrapf(err, "failed to connect to the gRPC: %s", protoAddr)
+		err := errors.Wrapf(err, "failed to connect to the gRPC: %s", network.ExchangeGrpcEndpoint)
 		return nil, err
 	}
 
 	// build client
 	cc := &exchangeClient{
-		opts: opts,
-		conn: conn,
+		opts:    opts,
+		network: network,
+		conn:    conn,
 
 		metaClient:               metaPB.NewInjectiveMetaRPCClient(conn),
 		explorerClient:           explorerPB.NewInjectiveExplorerRPCClient(conn),
@@ -138,10 +141,11 @@ func NewExchangeClient(protoAddr string, options ...common.ClientOption) (Exchan
 }
 
 type exchangeClient struct {
-	opts   *common.ClientOptions
-	conn   *grpc.ClientConn
-	logger log.Logger
-	client *grpc.ClientConn
+	opts    *common.ClientOptions
+	network common.Network
+	conn    *grpc.ClientConn
+	logger  log.Logger
+	client  *grpc.ClientConn
 
 	sessionCookie string
 
@@ -158,15 +162,17 @@ type exchangeClient struct {
 	closed int64
 }
 
-func (c *exchangeClient) setCookie(metadata metadata.MD) {
-	md := metadata.Get("set-cookie")
-	if len(md) > 0 {
-		c.sessionCookie = md[0]
-	}
+func (c *exchangeClient) requestCookie() metadata.MD {
+	var header metadata.MD
+	req := metaPB.InfoRequest{}
+	c.metaClient.Info(context.Background(), &req, grpc.Header(&header))
+	return header
 }
 
 func (c *exchangeClient) getCookie(ctx context.Context) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, "cookie", c.sessionCookie)
+	provider := common.NewMetadataProvider(c.requestCookie)
+	cookie, _ := c.network.ExchangeMetadata(provider)
+	return metadata.AppendToOutgoingContext(ctx, "cookie", cookie)
 }
 
 func (c *exchangeClient) QueryClient() *grpc.ClientConn {
@@ -176,27 +182,23 @@ func (c *exchangeClient) QueryClient() *grpc.ClientConn {
 // Derivatives RPC
 
 func (c *exchangeClient) GetDerivativeOrders(ctx context.Context, req derivativeExchangePB.OrdersRequest) (derivativeExchangePB.OrdersResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Orders(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Orders(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.OrdersResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetDerivativePositions(ctx context.Context, req derivativeExchangePB.PositionsRequest) (derivativeExchangePB.PositionsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Positions(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Positions(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.PositionsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -206,14 +208,12 @@ func (c *exchangeClient) GetDerivativeOrderbook(ctx context.Context, marketId st
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Orderbook(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Orderbook(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.OrderbookResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -223,14 +223,12 @@ func (c *exchangeClient) GetDerivativeOrderbooks(ctx context.Context, marketIds 
 		MarketIds: marketIds,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Orderbooks(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Orderbooks(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.OrderbooksResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -240,14 +238,12 @@ func (c *exchangeClient) GetDerivativeOrderbookV2(ctx context.Context, marketId 
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.OrderbookV2(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.OrderbookV2(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.OrderbookV2Response{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -257,14 +253,12 @@ func (c *exchangeClient) GetDerivativeOrderbooksV2(ctx context.Context, marketId
 		MarketIds: marketIds,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.OrderbooksV2(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.OrderbooksV2(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.OrderbooksV2Response{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -280,12 +274,6 @@ func (c *exchangeClient) StreamDerivativeOrderbook(ctx context.Context, marketId
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -301,12 +289,6 @@ func (c *exchangeClient) StreamDerivativeOrderbookV2(ctx context.Context, market
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -322,25 +304,17 @@ func (c *exchangeClient) StreamDerivativeOrderbookUpdate(ctx context.Context, ma
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetDerivativeMarkets(ctx context.Context, req derivativeExchangePB.MarketsRequest) (derivativeExchangePB.MarketsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Markets(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Markets(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.MarketsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -350,14 +324,12 @@ func (c *exchangeClient) GetDerivativeMarket(ctx context.Context, marketId strin
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Market(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Market(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.MarketResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -373,12 +345,6 @@ func (c *exchangeClient) StreamDerivativeMarket(ctx context.Context, marketIds [
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -390,12 +356,6 @@ func (c *exchangeClient) StreamDerivativePositions(ctx context.Context, req deri
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -407,25 +367,17 @@ func (c *exchangeClient) StreamDerivativeOrders(ctx context.Context, req derivat
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetDerivativeTrades(ctx context.Context, req derivativeExchangePB.TradesRequest) (derivativeExchangePB.TradesResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.Trades(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.Trades(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.TradesResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -437,64 +389,50 @@ func (c *exchangeClient) StreamDerivativeTrades(ctx context.Context, req derivat
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetSubaccountDerivativeOrdersList(ctx context.Context, req derivativeExchangePB.SubaccountOrdersListRequest) (derivativeExchangePB.SubaccountOrdersListResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.SubaccountOrdersList(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.SubaccountOrdersList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.SubaccountOrdersListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetSubaccountDerivativeTradesList(ctx context.Context, req derivativeExchangePB.SubaccountTradesListRequest) (derivativeExchangePB.SubaccountTradesListResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.SubaccountTradesList(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.SubaccountTradesList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.SubaccountTradesListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetDerivativeFundingPayments(ctx context.Context, req derivativeExchangePB.FundingPaymentsRequest) (derivativeExchangePB.FundingPaymentsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.FundingPayments(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.FundingPayments(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.FundingPaymentsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetDerivativeFundingRates(ctx context.Context, req derivativeExchangePB.FundingRatesRequest) (derivativeExchangePB.FundingRatesResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.derivativeExchangeClient.FundingRates(ctx, &req, grpc.Header(&header))
+	res, err := c.derivativeExchangeClient.FundingRates(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.FundingRatesResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -509,14 +447,12 @@ func (c *exchangeClient) GetPrice(ctx context.Context, baseSymbol string, quoteS
 		OracleScaleFactor: oracleScaleFactor,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.oracleClient.Price(ctx, &req, grpc.Header(&header))
+	res, err := c.oracleClient.Price(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return oraclePB.PriceResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -524,14 +460,12 @@ func (c *exchangeClient) GetPrice(ctx context.Context, baseSymbol string, quoteS
 func (c *exchangeClient) GetOracleList(ctx context.Context) (oraclePB.OracleListResponse, error) {
 	req := oraclePB.OracleListRequest{}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.oracleClient.OracleList(ctx, &req, grpc.Header(&header))
+	res, err := c.oracleClient.OracleList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return oraclePB.OracleListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -549,12 +483,6 @@ func (c *exchangeClient) StreamPrices(ctx context.Context, baseSymbol string, qu
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -566,14 +494,12 @@ func (c *exchangeClient) GetAuction(ctx context.Context, round int64) (auctionPB
 		Round: round,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.auctionClient.AuctionEndpoint(ctx, &req, grpc.Header(&header))
+	res, err := c.auctionClient.AuctionEndpoint(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return auctionPB.AuctionEndpointResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -581,14 +507,12 @@ func (c *exchangeClient) GetAuction(ctx context.Context, round int64) (auctionPB
 func (c *exchangeClient) GetAuctions(ctx context.Context) (auctionPB.AuctionsResponse, error) {
 	req := auctionPB.AuctionsRequest{}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.auctionClient.Auctions(ctx, &req, grpc.Header(&header))
+	res, err := c.auctionClient.Auctions(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return auctionPB.AuctionsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -602,12 +526,6 @@ func (c *exchangeClient) StreamBids(ctx context.Context) (auctionPB.InjectiveAuc
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -619,14 +537,12 @@ func (c *exchangeClient) GetSubaccountsList(ctx context.Context, accountAddress 
 		AccountAddress: accountAddress,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.SubaccountsList(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.SubaccountsList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.SubaccountsListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -637,14 +553,12 @@ func (c *exchangeClient) GetSubaccountBalance(ctx context.Context, subaccountId 
 		Denom:        denom,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.SubaccountBalanceEndpoint(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.SubaccountBalanceEndpoint(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.SubaccountBalanceEndpointResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -660,12 +574,6 @@ func (c *exchangeClient) StreamSubaccountBalance(ctx context.Context, subaccount
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -675,53 +583,45 @@ func (c *exchangeClient) GetSubaccountBalancesList(ctx context.Context, subaccou
 		SubaccountId: subaccountId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.SubaccountBalancesList(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.SubaccountBalancesList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.SubaccountBalancesListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetSubaccountHistory(ctx context.Context, req accountPB.SubaccountHistoryRequest) (accountPB.SubaccountHistoryResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.SubaccountHistory(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.SubaccountHistory(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.SubaccountHistoryResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetSubaccountOrderSummary(ctx context.Context, req accountPB.SubaccountOrderSummaryRequest) (accountPB.SubaccountOrderSummaryResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.SubaccountOrderSummary(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.SubaccountOrderSummary(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.SubaccountOrderSummaryResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetOrderStates(ctx context.Context, req accountPB.OrderStatesRequest) (accountPB.OrderStatesResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.OrderStates(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.OrderStates(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.OrderStatesResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -731,27 +631,23 @@ func (c *exchangeClient) GetPortfolio(ctx context.Context, accountAddress string
 		AccountAddress: accountAddress,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.Portfolio(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.Portfolio(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.PortfolioResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetRewards(ctx context.Context, req accountPB.RewardsRequest) (accountPB.RewardsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.accountClient.Rewards(ctx, &req, grpc.Header(&header))
+	res, err := c.accountClient.Rewards(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return accountPB.RewardsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -759,14 +655,12 @@ func (c *exchangeClient) GetRewards(ctx context.Context, req accountPB.RewardsRe
 // Spot RPC
 
 func (c *exchangeClient) GetSpotOrders(ctx context.Context, req spotExchangePB.OrdersRequest) (spotExchangePB.OrdersResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Orders(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Orders(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.OrdersResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -776,14 +670,12 @@ func (c *exchangeClient) GetSpotOrderbook(ctx context.Context, marketId string) 
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Orderbook(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Orderbook(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.OrderbookResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -793,14 +685,12 @@ func (c *exchangeClient) GetSpotOrderbookV2(ctx context.Context, marketId string
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.OrderbookV2(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.OrderbookV2(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.OrderbookV2Response{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -810,14 +700,12 @@ func (c *exchangeClient) GetSpotOrderbooks(ctx context.Context, marketIds []stri
 		MarketIds: marketIds,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Orderbooks(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Orderbooks(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.OrderbooksResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -827,14 +715,12 @@ func (c *exchangeClient) GetSpotOrderbooksV2(ctx context.Context, marketIds []st
 		MarketIds: marketIds,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.OrderbooksV2(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.OrderbooksV2(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.OrderbooksV2Response{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -850,12 +736,6 @@ func (c *exchangeClient) StreamSpotOrderbookUpdate(ctx context.Context, marketId
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -871,12 +751,6 @@ func (c *exchangeClient) StreamSpotOrderbook(ctx context.Context, marketIds []st
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -892,25 +766,17 @@ func (c *exchangeClient) StreamSpotOrderbookV2(ctx context.Context, marketIds []
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetSpotMarkets(ctx context.Context, req spotExchangePB.MarketsRequest) (spotExchangePB.MarketsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Markets(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Markets(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.MarketsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -920,14 +786,12 @@ func (c *exchangeClient) GetSpotMarket(ctx context.Context, marketId string) (sp
 		MarketId: marketId,
 	}
 
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Market(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Market(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.MarketResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -943,12 +807,6 @@ func (c *exchangeClient) StreamSpotMarket(ctx context.Context, marketIds []strin
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
@@ -960,25 +818,17 @@ func (c *exchangeClient) StreamSpotOrders(ctx context.Context, req spotExchangeP
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetSpotTrades(ctx context.Context, req spotExchangePB.TradesRequest) (spotExchangePB.TradesResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.Trades(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.Trades(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.TradesResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -990,103 +840,83 @@ func (c *exchangeClient) StreamSpotTrades(ctx context.Context, req spotExchangeP
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetSubaccountSpotOrdersList(ctx context.Context, req spotExchangePB.SubaccountOrdersListRequest) (spotExchangePB.SubaccountOrdersListResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.SubaccountOrdersList(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.SubaccountOrdersList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.SubaccountOrdersListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetSubaccountSpotTradesList(ctx context.Context, req spotExchangePB.SubaccountTradesListRequest) (spotExchangePB.SubaccountTradesListResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.spotExchangeClient.SubaccountTradesList(ctx, &req, grpc.Header(&header))
+	res, err := c.spotExchangeClient.SubaccountTradesList(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return spotExchangePB.SubaccountTradesListResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetInsuranceFunds(ctx context.Context, req insurancePB.FundsRequest) (insurancePB.FundsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.insuranceClient.Funds(ctx, &req, grpc.Header(&header))
+	res, err := c.insuranceClient.Funds(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return insurancePB.FundsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetRedemptions(ctx context.Context, req insurancePB.RedemptionsRequest) (insurancePB.RedemptionsResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.insuranceClient.Redemptions(ctx, &req, grpc.Header(&header))
+	res, err := c.insuranceClient.Redemptions(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return insurancePB.RedemptionsResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) Ping(ctx context.Context, req metaPB.PingRequest) (metaPB.PingResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.metaClient.Ping(ctx, &req, grpc.Header(&header))
+	res, err := c.metaClient.Ping(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return metaPB.PingResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetVersion(ctx context.Context, req metaPB.VersionRequest) (metaPB.VersionResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.metaClient.Version(ctx, &req, grpc.Header(&header))
+	res, err := c.metaClient.Version(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return metaPB.VersionResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) GetInfo(ctx context.Context, req metaPB.InfoRequest) (metaPB.InfoResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
-	res, err := c.metaClient.Info(ctx, &req, grpc.Header(&header))
+	res, err := c.metaClient.Info(ctx, &req)
 	if err != nil {
 		fmt.Println(err)
 		return metaPB.InfoResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
@@ -1100,49 +930,34 @@ func (c *exchangeClient) StreamKeepalive(ctx context.Context) (metaPB.InjectiveM
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err := stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }
 
 func (c *exchangeClient) GetAccountPortfolio(ctx context.Context, accountAddress string) (portfolioExchangePB.AccountPortfolioResponse, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
 	res, err := c.portfolioExchangeClient.AccountPortfolio(ctx, &portfolioExchangePB.AccountPortfolioRequest{
 		AccountAddress: accountAddress,
-	}, grpc.Header(&header))
+	})
 	if err != nil {
 		fmt.Println(err)
 		return portfolioExchangePB.AccountPortfolioResponse{}, err
 	}
-	c.setCookie(header)
 
 	return *res, nil
 }
 
 func (c *exchangeClient) StreamAccountPortfolio(ctx context.Context, accountAddress string, subaccountId, balanceType string) (portfolioExchangePB.InjectivePortfolioRPC_StreamAccountPortfolioClient, error) {
-	var header metadata.MD
 	ctx = c.getCookie(ctx)
 	stream, err := c.portfolioExchangeClient.StreamAccountPortfolio(ctx, &portfolioExchangePB.StreamAccountPortfolioRequest{
 		AccountAddress: accountAddress,
 		SubaccountId:   subaccountId,
 		Type:           balanceType,
-	}, grpc.Header(&header))
+	})
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
 	}
-	header, err = stream.Header()
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	c.setCookie(header)
 
 	return stream, nil
 }

--- a/client/metadata/fetch_metadata.go
+++ b/client/metadata/fetch_metadata.go
@@ -42,7 +42,7 @@ decimals = %s
 func FetchDenom(network common.Network) {
 	metadataOutput := ""
 	symbols := make(map[string][]string)
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}
@@ -143,8 +143,8 @@ func FetchDenom(network common.Network) {
 
 func main() {
 	devnet := common.LoadNetwork("devnet", "")
-	testnet := common.LoadNetwork("testnet", "k8s")
-	mainnet := common.LoadNetwork("mainnet", "k8s")
+	testnet := common.LoadNetwork("testnet", "lb")
+	mainnet := common.LoadNetwork("mainnet", "lb")
 	FetchDenom(devnet)
 	FetchDenom(testnet)
 	FetchDenom(mainnet)

--- a/examples/chain/0_LocalOrderHash/example.go
+++ b/examples/chain/0_LocalOrderHash/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/10_MsgBatchCancelDerivativeOrders/example.go
+++ b/examples/chain/10_MsgBatchCancelDerivativeOrders/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/11_MsgBatchCreateSpotLimitOrders/example.go
+++ b/examples/chain/11_MsgBatchCreateSpotLimitOrders/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -50,8 +49,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/12_MsgBatchCreateDerivativeLimitOrders/example.go
+++ b/examples/chain/12_MsgBatchCreateDerivativeLimitOrders/example.go
@@ -15,8 +15,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -51,8 +50,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/13_MsgIncreasePositionMargin/example.go
+++ b/examples/chain/13_MsgIncreasePositionMargin/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -57,8 +56,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/15_MsgWithdraw/example.go
+++ b/examples/chain/15_MsgWithdraw/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -57,8 +56,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/16_MsgSubaccountTransfer/example.go
+++ b/examples/chain/16_MsgSubaccountTransfer/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -58,8 +57,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/17_MsgBatchUpdateOrders/example.go
+++ b/examples/chain/17_MsgBatchUpdateOrders/example.go
@@ -15,8 +15,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -51,8 +50,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/18_MsgBid/example.go
+++ b/examples/chain/18_MsgBid/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -60,8 +59,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/19_MsgGrant/example.go
+++ b/examples/chain/19_MsgGrant/example.go
@@ -12,8 +12,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -47,8 +46,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/1_MsgSend/example.go
+++ b/examples/chain/1_MsgSend/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -57,8 +56,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/20_MsgExec/example.go
+++ b/examples/chain/20_MsgExec/example.go
@@ -17,8 +17,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -68,8 +67,7 @@ func main() {
 	txFactory = txFactory.WithGasPrices("500000000inj")
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionTxFactory(&txFactory),
 	)
 

--- a/examples/chain/21_MsgRevoke/example.go
+++ b/examples/chain/21_MsgRevoke/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -57,8 +56,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/22_MsgSendToEth/example.go
+++ b/examples/chain/22_MsgSendToEth/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -65,8 +64,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/23_MsgRelayPriceFeedPrice/example.go
+++ b/examples/chain/23_MsgRelayPriceFeedPrice/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -60,8 +59,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/24_MsgRegisterAsDMM/example.go
+++ b/examples/chain/24_MsgRegisterAsDMM/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -52,8 +51,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/25_MsgDelegate/example.go
+++ b/examples/chain/25_MsgDelegate/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/26_MsgWithdrawDelegatorReward/example.go
+++ b/examples/chain/26_MsgWithdrawDelegatorReward/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -48,8 +47,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/27_QueryAuthzGrants/example.go
+++ b/examples/chain/27_QueryAuthzGrants/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/28_BankBalances/example.go
+++ b/examples/chain/28_BankBalances/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -48,8 +47,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/29_BankBalance/example.go
+++ b/examples/chain/29_BankBalance/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -48,8 +47,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/2_MsgDeposit/example.go
+++ b/examples/chain/2_MsgDeposit/example.go
@@ -15,8 +15,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -56,8 +55,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/30_MsgExternalTransfer/example.go
+++ b/examples/chain/30_MsgExternalTransfer/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -58,8 +57,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/31_MsgMultiSend/example.go
+++ b/examples/chain/31_MsgMultiSend/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -84,8 +83,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/33_GetBlock/example.go
+++ b/examples/chain/33_GetBlock/example.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient := tmclient.NewRPCClient(network.TmEndpoint)
 	clientCtx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()

--- a/examples/chain/34_OfflineSigning/example.go
+++ b/examples/chain/34_OfflineSigning/example.go
@@ -62,8 +62,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/35_StreamEventOrderFail/example.go
+++ b/examples/chain/35_StreamEventOrderFail/example.go
@@ -5,15 +5,10 @@ import (
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
-	network := common.LoadNetwork("mainnet", "sentry0")
-	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
-	if err != nil {
-		panic(err)
-	}
+	network := common.LoadNetwork("mainnet", "lb")
 
 	clientCtx, err := chainclient.NewClientContext(
 		network.ChainId,
@@ -23,12 +18,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 	if err != nil {

--- a/examples/chain/36_StreamEventOrderbookUpdate/example.go
+++ b/examples/chain/36_StreamEventOrderbookUpdate/example.go
@@ -6,15 +6,10 @@ import (
 	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
-	network := common.LoadNetwork("devnet", "")
-	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
-	if err != nil {
-		panic(err)
-	}
+	network := common.LoadNetwork("mainnet", "lb")
 
 	clientCtx, err := chainclient.NewClientContext(
 		network.ChainId,
@@ -24,12 +19,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 	if err != nil {

--- a/examples/chain/38_MsgLiquidate/example.go
+++ b/examples/chain/38_MsgLiquidate/example.go
@@ -52,8 +52,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/39_GetTx/example.go
+++ b/examples/chain/39_GetTx/example.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("mainnet", "k8s")
+	network := common.LoadNetwork("mainnet", "lb")
 	tmRPC, err := rpchttp.New(network.TmEndpoint, "/websocket")
 
 	if err != nil {
@@ -50,8 +50,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/3_MsgCreateSpotLimitOrder/example.go
+++ b/examples/chain/3_MsgCreateSpotLimitOrder/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("mainnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -48,8 +47,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 
@@ -60,7 +58,7 @@ func main() {
 
 	defaultSubaccountID := chainClient.DefaultSubaccount(senderAddress)
 
-	marketId := "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
+	marketId := "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0"
 
 	amount := decimal.NewFromFloat(2)
 	price := decimal.NewFromFloat(22.55)

--- a/examples/chain/4_MsgCreateSpotMarketOrder/example.go
+++ b/examples/chain/4_MsgCreateSpotMarketOrder/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/5_MsgCancelSpotOrder/example.go
+++ b/examples/chain/5_MsgCancelSpotOrder/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -55,8 +54,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/6_MsgCreateDerivativeLimitOrder/example.go
+++ b/examples/chain/6_MsgCreateDerivativeLimitOrder/example.go
@@ -15,8 +15,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -50,8 +49,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/7_MsgCreateDerivativeMarketOrder/example.go
+++ b/examples/chain/7_MsgCreateDerivativeMarketOrder/example.go
@@ -15,8 +15,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -51,8 +50,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/8_MsgCancelDerivativeOrder/example.go
+++ b/examples/chain/8_MsgCancelDerivativeOrder/example.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -55,8 +54,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/chain/9_MsgBatchCancelSpotOrders/example.go
+++ b/examples/chain/9_MsgBatchCancelSpotOrders/example.go
@@ -14,8 +14,7 @@ import (
 )
 
 func main() {
-	// network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
+	network := common.LoadNetwork("testnet", "lb")
 	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
 	if err != nil {
 		panic(err)
@@ -49,8 +48,7 @@ func main() {
 
 	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
-		network.ChainGrpcEndpoint,
-		common.OptionTLSCert(network.ChainTlsCert),
+		network,
 		common.OptionGasPrices("500000000inj"),
 	)
 

--- a/examples/exchange/accounts/1_StreamSubaccountBalance/example.go
+++ b/examples/exchange/accounts/1_StreamSubaccountBalance/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/2_SubaccountBalance/example.go
+++ b/examples/exchange/accounts/2_SubaccountBalance/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("mainnet", "sentry")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("mainnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/3_SubaccountsList/example.go
+++ b/examples/exchange/accounts/3_SubaccountsList/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/4_SubaccountBalancesList/example.go
+++ b/examples/exchange/accounts/4_SubaccountBalancesList/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/5_SubaccountHistory/example.go
+++ b/examples/exchange/accounts/5_SubaccountHistory/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/6_SubaccountOrderSummary/example.go
+++ b/examples/exchange/accounts/6_SubaccountOrderSummary/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/7_OrderStates/example.go
+++ b/examples/exchange/accounts/7_OrderStates/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/8_Portfolio/example.go
+++ b/examples/exchange/accounts/8_Portfolio/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/accounts/9_Rewards/example.go
+++ b/examples/exchange/accounts/9_Rewards/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/auction/1_Auction/example.go
+++ b/examples/exchange/auction/1_Auction/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/auction/2_Auctions/example.go
+++ b/examples/exchange/auction/2_Auctions/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/auction/3_StreamBids/example.go
+++ b/examples/exchange/auction/3_StreamBids/example.go
@@ -10,9 +10,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/derivatives/10_StreamPositions/example.go
+++ b/examples/exchange/derivatives/10_StreamPositions/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/11_StreamOrders/example.go
+++ b/examples/exchange/derivatives/11_StreamOrders/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/12_Trades/example.go
+++ b/examples/exchange/derivatives/12_Trades/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/13_StreamTrades/example.go
+++ b/examples/exchange/derivatives/13_StreamTrades/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/14_SubaccountOrdersList/example.go
+++ b/examples/exchange/derivatives/14_SubaccountOrdersList/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/15_SubaccountTradesList/example.go
+++ b/examples/exchange/derivatives/15_SubaccountTradesList/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/16_FundingPayments/example.go
+++ b/examples/exchange/derivatives/16_FundingPayments/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/17_FundingRates/example.go
+++ b/examples/exchange/derivatives/17_FundingRates/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/1_Market/example.go
+++ b/examples/exchange/derivatives/1_Market/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/2_Markets/example.go
+++ b/examples/exchange/derivatives/2_Markets/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("mainnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("mainnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/3_StreamMarket/example.go
+++ b/examples/exchange/derivatives/3_StreamMarket/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/4_Orderbook/example.go
+++ b/examples/exchange/derivatives/4_Orderbook/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/5_Orderbooks/example.go
+++ b/examples/exchange/derivatives/5_Orderbooks/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/6_StreamOrderbook/example.go
+++ b/examples/exchange/derivatives/6_StreamOrderbook/example.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("devnet-1", "")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/derivatives/8_Positions/example.go
+++ b/examples/exchange/derivatives/8_Positions/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/derivatives/9_Orders/example.go
+++ b/examples/exchange/derivatives/9_Orders/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/insurance/1_InsuranceFunds/example.go
+++ b/examples/exchange/insurance/1_InsuranceFunds/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/insurance/2_Redemptions/example.go
+++ b/examples/exchange/insurance/2_Redemptions/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/meta/1_Ping/example.go
+++ b/examples/exchange/meta/1_Ping/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/meta/2_Version/example.go
+++ b/examples/exchange/meta/2_Version/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/meta/3_Info/example.go
+++ b/examples/exchange/meta/3_Info/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/meta/4_StreamKeepAlive/example.go
+++ b/examples/exchange/meta/4_StreamKeepAlive/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/oracle/1_StreamPrices/example.go
+++ b/examples/exchange/oracle/1_StreamPrices/example.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("mainnet", "lb")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/oracle/2_Price/example.go
+++ b/examples/exchange/oracle/2_Price/example.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("mainnet", "lb")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/oracle/3_OracleList/example.go
+++ b/examples/exchange/oracle/3_OracleList/example.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("mainnet", "lb")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/portfolio/1_AccountPortfolio/example.go
+++ b/examples/exchange/portfolio/1_AccountPortfolio/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	// select network: local, testnet, mainnet
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/exchange/portfolio/2_StreamAccountPortfolioBankBalances/example.go
+++ b/examples/exchange/portfolio/2_StreamAccountPortfolioBankBalances/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	// select network: local, testnet, mainnet
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/portfolio/3_StreamAccountPortfolioSubaccountBalances/example.go
+++ b/examples/exchange/portfolio/3_StreamAccountPortfolioSubaccountBalances/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	// select network: local, testnet, mainnet
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/10_StreamTrades/example.go
+++ b/examples/exchange/spot/10_StreamTrades/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/11_SubaccountOrdersList/example.go
+++ b/examples/exchange/spot/11_SubaccountOrdersList/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/12_SubaccountTradesList/example.go
+++ b/examples/exchange/spot/12_SubaccountTradesList/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/13_Orderbooks/example.go
+++ b/examples/exchange/spot/13_Orderbooks/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/1_Market/example.go
+++ b/examples/exchange/spot/1_Market/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/2_Markets/example.go
+++ b/examples/exchange/spot/2_Markets/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/3_StreamMarket/example.go
+++ b/examples/exchange/spot/3_StreamMarket/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/4_Orderbook/example.go
+++ b/examples/exchange/spot/4_Orderbook/example.go
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/5_Orders/example.go
+++ b/examples/exchange/spot/5_Orders/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/6_Trades/example.go
+++ b/examples/exchange/spot/6_Trades/example.go
@@ -11,9 +11,8 @@ import (
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/7_StreamOrderbook/example.go
+++ b/examples/exchange/spot/7_StreamOrderbook/example.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("devnet-1", "")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/exchange/spot/9_StreamOrders/example.go
+++ b/examples/exchange/spot/9_StreamOrders/example.go
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	//network := common.LoadNetwork("mainnet", "k8s")
-	network := common.LoadNetwork("testnet", "k8s")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint, common.OptionTLSCert(network.ExchangeTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/explorer/10_IBCTransfers/example.go
+++ b/examples/explorer/10_IBCTransfers/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/11_GetWasmCodes/example.go
+++ b/examples/explorer/11_GetWasmCodes/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/12_GetWasmCodeById/example.go
+++ b/examples/explorer/12_GetWasmCodeById/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/13_GetWasmContracts/example.go
+++ b/examples/explorer/13_GetWasmContracts/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/14_GetWasmContractByAddress/example.go
+++ b/examples/explorer/14_GetWasmContractByAddress/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/15_GetCW20Balance/example.go
+++ b/examples/explorer/15_GetCW20Balance/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/1_GetTxByHash/example.go
+++ b/examples/explorer/1_GetTxByHash/example.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("mainnet", "sentry")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/2_AccountTxs/example.go
+++ b/examples/explorer/2_AccountTxs/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/3_Blocks/example.go
+++ b/examples/explorer/3_Blocks/example.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	network := common.LoadNetwork("mainnet", "lb")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/4_Block/example.go
+++ b/examples/explorer/4_Block/example.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/5_TxsRequest/example.go
+++ b/examples/explorer/5_TxsRequest/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/6_StreamTxs/example.go
+++ b/examples/explorer/6_StreamTxs/example.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/7_StreamBlocks/example.go
+++ b/examples/explorer/7_StreamBlocks/example.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/8_PeggyDeposits/example.go
+++ b/examples/explorer/8_PeggyDeposits/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explorer/9_PeggyWithdrawals/example.go
+++ b/examples/explorer/9_PeggyWithdrawals/example.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "k8s")
-	explorerClient, err := explorerclient.NewExplorerClient(network.ExplorerGrpcEndpoint, common.OptionTLSCert(network.ExplorerTlsCert))
+	network := common.LoadNetwork("testnet", "lb")
+	explorerClient, err := explorerclient.NewExplorerClient(network)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Created new components to centralize the logic required to manage cookies for the load balanced servers.
- Included the cookie management inside the Network struct, so that users don't need to now which servers use cookies and which don't.
- Refactored Chain, Exchange and Explorer clients to receive the Network when being instantiated. The use the Network instance to get the cookie when they need to interact with the server.

I have also added a refactoring to not try to automatically start a websocket connection with the server when creating an instance of ChainClient. There are only two functions that required that connection, and they are seldomly used. The connection should be stablished only when required.

I am sending the changes to `dev` branch, in case there are other changes in parallel we should synchronize with before reaching the `master` branch