### PR TITLE
feat/add_historical_orders_support

### DIFF
--- a/client/common/network.go
+++ b/client/common/network.go
@@ -211,7 +211,7 @@ func LoadNetwork(name string, node string) Network {
 			explorerCookieAssistant: &DisabledCookieAssistant{},
 		}
 	case "testnet":
-		validNodes := []string{"lb", "lb_k8s", "sentry", "sentry0", "sentry1"}
+		validNodes := []string{"lb", "lb_k8s", "sentry"}
 		if !contains(validNodes, node) {
 			panic(fmt.Sprintf("invalid node %s for %s", node, name))
 		}
@@ -259,15 +259,6 @@ func LoadNetwork(name string, node string) Network {
 			chainCookieAssistant = &DisabledCookieAssistant{}
 			exchangeCookieAssistant = &DisabledCookieAssistant{}
 			explorerCookieAssistant = &DisabledCookieAssistant{}
-		} else {
-			lcdEndpoint = fmt.Sprintf("http://%s.injective.dev:10337", node)
-			tmEndpoint = fmt.Sprintf("http://%s.injective.dev:26657", node)
-			chainGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.dev:9900", node)
-			exchangeGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.dev:9910", node)
-			explorerGrpcEndpoint = "tcp://testnet.api.injective.dev:9911"
-			chainCookieAssistant = &DisabledCookieAssistant{}
-			exchangeCookieAssistant = &DisabledCookieAssistant{}
-			explorerCookieAssistant = &DisabledCookieAssistant{}
 		}
 
 		return Network{
@@ -287,7 +278,7 @@ func LoadNetwork(name string, node string) Network {
 			explorerCookieAssistant: explorerCookieAssistant,
 		}
 	case "mainnet":
-		validNodes := []string{"lb", "lb_k8s", "sentry0", "sentry1", "sentry2", "sentry3"}
+		validNodes := []string{"lb", "lb_k8s"}
 		if !contains(validNodes, node) {
 			panic(fmt.Sprintf("invalid node %s for %s", node, name))
 		}
@@ -307,7 +298,6 @@ func LoadNetwork(name string, node string) Network {
 			exchangeCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
 			explorerCookieAssistant = &BareMetalLoadBalancedCookieAssistant{}
 		} else if node == "lb_k8s" {
-			//certPath := getFileAbsPath("../cert/mainnet.crt")
 			lcdEndpoint = "https://k8s.global.mainnet.lcd.injective.network"
 			tmEndpoint = "https://k8s.global.mainnet.tm.injective.network:443"
 			chainGrpcEndpoint = "k8s.global.mainnet.chain.grpc.injective.network:443"
@@ -322,21 +312,6 @@ func LoadNetwork(name string, node string) Network {
 			exchangeCookieAssistant = &exchangeAssistant
 			explorerAssistant := MainnetKubernetesCookieAssistant()
 			explorerCookieAssistant = &explorerAssistant
-		} else {
-			lcdEndpoint = fmt.Sprintf("http://%s.injective.network:10337", node)
-			tmEndpoint = fmt.Sprintf("http://%s.injective.network:26657", node)
-			chainGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.network:9900", node)
-			exchangeGrpcEndpoint = fmt.Sprintf("tcp://%s.injective.network:9910", node)
-			// only sentry2 and equinix-0 have explorer
-			if node == "sentry2" {
-				explorerGrpcEndpoint = "tcp://sentry2.injective.network:9911"
-			} else {
-				explorerGrpcEndpoint = "k8s.global.mainnet.explorer.grpc.injective.network:443"
-				explorerTlsCert = credentials.NewServerTLSFromCert(&tls.Certificate{})
-			}
-			chainCookieAssistant = &DisabledCookieAssistant{}
-			exchangeCookieAssistant = &DisabledCookieAssistant{}
-			explorerCookieAssistant = &DisabledCookieAssistant{}
 		}
 
 		return Network{

--- a/client/exchange/exchange.go
+++ b/client/exchange/exchange.go
@@ -35,12 +35,15 @@ type ExchangeClient interface {
 	GetDerivativeOrders(ctx context.Context, req derivativeExchangePB.OrdersRequest) (derivativeExchangePB.OrdersResponse, error)
 	GetDerivativeMarkets(ctx context.Context, req derivativeExchangePB.MarketsRequest) (derivativeExchangePB.MarketsResponse, error)
 	GetDerivativePositions(ctx context.Context, req derivativeExchangePB.PositionsRequest) (derivativeExchangePB.PositionsResponse, error)
+	GetDerivativeLiquidablePositions(ctx context.Context, req derivativeExchangePB.LiquidablePositionsRequest) (derivativeExchangePB.LiquidablePositionsResponse, error)
 	StreamDerivativePositions(ctx context.Context, req derivativeExchangePB.StreamPositionsRequest) (derivativeExchangePB.InjectiveDerivativeExchangeRPC_StreamPositionsClient, error)
 	StreamDerivativeOrders(ctx context.Context, req derivativeExchangePB.StreamOrdersRequest) (derivativeExchangePB.InjectiveDerivativeExchangeRPC_StreamOrdersClient, error)
 	GetDerivativeTrades(ctx context.Context, req derivativeExchangePB.TradesRequest) (derivativeExchangePB.TradesResponse, error)
 	StreamDerivativeTrades(ctx context.Context, req derivativeExchangePB.StreamTradesRequest) (derivativeExchangePB.InjectiveDerivativeExchangeRPC_StreamTradesClient, error)
 	GetSubaccountDerivativeOrdersList(ctx context.Context, req derivativeExchangePB.SubaccountOrdersListRequest) (derivativeExchangePB.SubaccountOrdersListResponse, error)
 	GetSubaccountDerivativeTradesList(ctx context.Context, req derivativeExchangePB.SubaccountTradesListRequest) (derivativeExchangePB.SubaccountTradesListResponse, error)
+	GetHistoricalDerivativeOrders(ctx context.Context, req derivativeExchangePB.OrdersHistoryRequest) (derivativeExchangePB.OrdersHistoryResponse, error)
+	StreamHistoricalDerivativeOrders(ctx context.Context, req derivativeExchangePB.StreamOrdersHistoryRequest) (derivativeExchangePB.InjectiveDerivativeExchangeRPC_StreamOrdersHistoryClient, error)
 	GetDerivativeFundingPayments(ctx context.Context, req derivativeExchangePB.FundingPaymentsRequest) (derivativeExchangePB.FundingPaymentsResponse, error)
 	GetDerivativeFundingRates(ctx context.Context, req derivativeExchangePB.FundingRatesRequest) (derivativeExchangePB.FundingRatesResponse, error)
 	GetPrice(ctx context.Context, baseSymbol string, quoteSymbol string, oracleType string, oracleScaleFactor uint32) (oraclePB.PriceResponse, error)
@@ -75,6 +78,8 @@ type ExchangeClient interface {
 	StreamSpotTrades(ctx context.Context, req spotExchangePB.StreamTradesRequest) (spotExchangePB.InjectiveSpotExchangeRPC_StreamTradesClient, error)
 	GetSubaccountSpotOrdersList(ctx context.Context, req spotExchangePB.SubaccountOrdersListRequest) (spotExchangePB.SubaccountOrdersListResponse, error)
 	GetSubaccountSpotTradesList(ctx context.Context, req spotExchangePB.SubaccountTradesListRequest) (spotExchangePB.SubaccountTradesListResponse, error)
+	GetHistoricalSpotOrders(ctx context.Context, req spotExchangePB.OrdersHistoryRequest) (spotExchangePB.OrdersHistoryResponse, error)
+	StreamHistoricalSpotOrders(ctx context.Context, req spotExchangePB.StreamOrdersHistoryRequest) (spotExchangePB.InjectiveSpotExchangeRPC_StreamOrdersHistoryClient, error)
 	GetInsuranceFunds(ctx context.Context, req insurancePB.FundsRequest) (insurancePB.FundsResponse, error)
 	GetRedemptions(ctx context.Context, req insurancePB.RedemptionsRequest) (insurancePB.RedemptionsResponse, error)
 
@@ -198,6 +203,17 @@ func (c *exchangeClient) GetDerivativePositions(ctx context.Context, req derivat
 	if err != nil {
 		fmt.Println(err)
 		return derivativeExchangePB.PositionsResponse{}, err
+	}
+
+	return *res, nil
+}
+
+func (c *exchangeClient) GetDerivativeLiquidablePositions(ctx context.Context, req derivativeExchangePB.LiquidablePositionsRequest) (derivativeExchangePB.LiquidablePositionsResponse, error) {
+	ctx = c.getCookie(ctx)
+	res, err := c.derivativeExchangeClient.LiquidablePositions(ctx, &req)
+	if err != nil {
+		fmt.Println(err)
+		return derivativeExchangePB.LiquidablePositionsResponse{}, err
 	}
 
 	return *res, nil
@@ -413,6 +429,27 @@ func (c *exchangeClient) GetSubaccountDerivativeTradesList(ctx context.Context, 
 	}
 
 	return *res, nil
+}
+
+func (c *exchangeClient) GetHistoricalDerivativeOrders(ctx context.Context, req derivativeExchangePB.OrdersHistoryRequest) (derivativeExchangePB.OrdersHistoryResponse, error) {
+	ctx = c.getCookie(ctx)
+	res, err := c.derivativeExchangeClient.OrdersHistory(ctx, &req)
+	if err != nil {
+		return derivativeExchangePB.OrdersHistoryResponse{}, err
+	}
+
+	return *res, nil
+}
+
+func (c *exchangeClient) StreamHistoricalDerivativeOrders(ctx context.Context, req derivativeExchangePB.StreamOrdersHistoryRequest) (derivativeExchangePB.InjectiveDerivativeExchangeRPC_StreamOrdersHistoryClient, error) {
+	ctx = c.getCookie(ctx)
+	stream, err := c.derivativeExchangeClient.StreamOrdersHistory(ctx, &req)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	return stream, nil
 }
 
 func (c *exchangeClient) GetDerivativeFundingPayments(ctx context.Context, req derivativeExchangePB.FundingPaymentsRequest) (derivativeExchangePB.FundingPaymentsResponse, error) {
@@ -864,6 +901,27 @@ func (c *exchangeClient) GetSubaccountSpotTradesList(ctx context.Context, req sp
 	}
 
 	return *res, nil
+}
+
+func (c *exchangeClient) GetHistoricalSpotOrders(ctx context.Context, req spotExchangePB.OrdersHistoryRequest) (spotExchangePB.OrdersHistoryResponse, error) {
+	ctx = c.getCookie(ctx)
+	res, err := c.spotExchangeClient.OrdersHistory(ctx, &req)
+	if err != nil {
+		return spotExchangePB.OrdersHistoryResponse{}, err
+	}
+
+	return *res, nil
+}
+
+func (c *exchangeClient) StreamHistoricalSpotOrders(ctx context.Context, req spotExchangePB.StreamOrdersHistoryRequest) (spotExchangePB.InjectiveSpotExchangeRPC_StreamOrdersHistoryClient, error) {
+	ctx = c.getCookie(ctx)
+	stream, err := c.spotExchangeClient.StreamOrdersHistory(ctx, &req)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	return stream, nil
 }
 
 func (c *exchangeClient) GetInsuranceFunds(ctx context.Context, req insurancePB.FundsRequest) (insurancePB.FundsResponse, error) {

--- a/examples/exchange/derivatives/18_HistoricalOrders/example.go
+++ b/examples/exchange/derivatives/18_HistoricalOrders/example.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
+	subaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+	skip := uint64(0)
+	limit := int32(10)
+	isConditional := "false"
+
+	req := derivativeExchangePB.OrdersHistoryRequest{
+		SubaccountId:  subaccountId,
+		MarketId:      marketId,
+		Skip:          skip,
+		Limit:         limit,
+		IsConditional: isConditional,
+	}
+
+	res, err := exchangeClient.GetHistoricalDerivativeOrders(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/exchange/derivatives/19_StreamHistoricalOrders/example.go
+++ b/examples/exchange/derivatives/19_StreamHistoricalOrders/example.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
+	subaccountId := "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
+	direction := "buy"
+
+	req := derivativeExchangePB.StreamOrdersHistoryRequest{
+		MarketId:     marketId,
+		SubaccountId: subaccountId,
+		Direction:    direction,
+	}
+	stream, err := exchangeClient.StreamHistoricalDerivativeOrders(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			res, err := stream.Recv()
+			if err != nil {
+				panic(err)
+				return
+			}
+			str, _ := json.MarshalIndent(res, "", " ")
+			fmt.Print(string(str))
+		}
+	}
+}

--- a/examples/exchange/derivatives/20_LiquidablePositions/example.go
+++ b/examples/exchange/derivatives/20_LiquidablePositions/example.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "sentry1")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
+	skip := uint64(0)
+	limit := int32(10)
+
+	req := derivativeExchangePB.LiquidablePositionsRequest{
+		MarketId: marketId,
+		Skip:     skip,
+		Limit:    limit,
+	}
+
+	res, err := exchangeClient.GetDerivativeLiquidablePositions(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/exchange/derivatives/20_LiquidablePositions/example.go
+++ b/examples/exchange/derivatives/20_LiquidablePositions/example.go
@@ -11,21 +11,21 @@ import (
 )
 
 func main() {
-	network := common.LoadNetwork("testnet", "sentry1")
+	network := common.LoadNetwork("testnet", "lb")
 	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
-	marketId := "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
+	//marketId := "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
 	skip := uint64(0)
 	limit := int32(10)
 
 	req := derivativeExchangePB.LiquidablePositionsRequest{
-		MarketId: marketId,
-		Skip:     skip,
-		Limit:    limit,
+		//MarketId: marketId,
+		Skip:  skip,
+		Limit: limit,
 	}
 
 	res, err := exchangeClient.GetDerivativeLiquidablePositions(ctx, req)

--- a/examples/exchange/spot/14_HistoricalOrders/example.go
+++ b/examples/exchange/spot/14_HistoricalOrders/example.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
+	subaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+	skip := uint64(0)
+	limit := int32(10)
+	orderTypes := []string{"buy_po"}
+
+	req := spotExchangePB.OrdersHistoryRequest{
+		SubaccountId: subaccountId,
+		MarketId:     marketId,
+		Skip:         skip,
+		Limit:        limit,
+		OrderTypes:   orderTypes,
+	}
+
+	res, err := exchangeClient.GetHistoricalSpotOrders(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/exchange/spot/15_StreamHistoricalOrders/example.go
+++ b/examples/exchange/spot/15_StreamHistoricalOrders/example.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
+	subaccountId := "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
+	direction := "buy"
+
+	req := spotExchangePB.StreamOrdersHistoryRequest{
+		MarketId:     marketId,
+		SubaccountId: subaccountId,
+		Direction:    direction,
+	}
+	stream, err := exchangeClient.StreamHistoricalSpotOrders(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			res, err := stream.Recv()
+			if err != nil {
+				panic(err)
+				return
+			}
+			str, _ := json.MarshalIndent(res, "", " ")
+			fmt.Print(string(str))
+		}
+	}
+}


### PR DESCRIPTION
- Added support for historical orders request for spot and derivative markets
- Added support for historical orders stream for spot and derivative markets
- Added support for liquidable positions request
- Removed sentry nodes from network configuration