### PR TITLE
(feat) Changed fetch_metadata script to ensure numbers are writen wit…

### DIFF
--- a/client/metadata/assets/devnet.ini
+++ b/client/metadata/assets/devnet.ini
@@ -1,116 +1,336 @@
-[0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce]
-description = 'devnet Derivative BTC/USDT PERP'
-base = 0
+[0x01edfab47f124748dc89998eb33144af734484ba07099014594321729a0ca16b]
+description = 'Devnet Spot AAVE/USDT'
+base = 18
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0x979731deaaf17d26b2e256ad18fecd0ac742b3746b9ea5382bac9bd0b5e58f74]
-description = 'devnet Derivative ETH/USDT PERP'
-base = 0
+[0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa]
+description = 'Devnet Spot ATOM/USDT'
+base = 6
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
 
-[0x1f73e21972972c69c03fb105a5864592ac2b47996ffea3c500d1ea2d20138717]
-description = 'devnet Derivative LINK/USDT PERP'
-base = 0
+[0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034]
+description = 'Devnet Spot WETH/USDT'
+base = 18
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0xb64332daa987dcb200c26965bc9adaf8aa301fe3a0aecb0232fadbd3dfccd0d8]
-description = 'devnet Derivative UNI/USDT PERP'
-base = 0
+[0xe97ebaf3e2ae3bd00dabe59046fcc28ec58ea969df33a9ce95f4fc285306c2d4]
+description = 'Devnet Spot WBTC/USDT'
+base = 18
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0x1c284820f24dff4c60fecd521a9df3df9c745d23dd585d45bf418653c2d73ab4]
-description = 'devnet Derivative SNX/USDT PERP'
-base = 0
+[0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31]
+description = 'Devnet Spot LINK/USDT'
+base = 18
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0xccd6723224cae013827668ad1e7f361cde694adbb7a87f62a6d547cc464ba9b5]
-description = 'devnet Derivative GRT/USDT PERP'
-base = 0
+[0x28f3c9897e23750bf653889224f93390c467b83c86d736af79431958fff833d1]
+description = 'Devnet Spot MATIC/USDT'
+base = 18
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0x74b17b0d6855feba39f1f7ab1e8bad0363bd510ee1dcc74e40c2adfe1502f781]
+description = 'Devnet Spot BNB/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0x572f05fd93a6c2c4611b2eba1a0a36e102b6a592781956f0128a27662d84f112]
+description = 'Devnet Spot APE/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0x74ee114ad750f8429a97e07b5e73e145724e9b21670a7666625ddacc03d6758d]
+description = 'Devnet Spot YFI/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0x7f71c4fba375c964be8db7fc7a5275d974f8c6cdc4d758f2ac4997f106bb052b]
+description = 'Devnet Spot GF/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 100000
+min_display_quantity_tick_size = 0.0000000000001
+
+[0x8b1a4d3e8f6b559e30e40922ee3662dd78edf7042330d4d620d188699d1a9715]
+description = 'Devnet Spot USDT/USDC'
+base = 6
+quote = 6
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
+
+[0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0]
+description = 'Devnet Spot INJ/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0x6fa856bca5a9298ced8da3ef7616e66081ff64e4fdd2bffa38e95cf23c1f2321]
+description = 'Devnet Spot PROJ/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.001
+min_display_price_tick_size = 1000000000
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.000000000000001
+
+[0x0686357b934c761784d58a2b8b12618dfe557de108a220e06f8f6580abb83aab]
+description = 'Devnet Spot SOMM/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 10000000
+min_display_quantity_tick_size = 10
+
+[0x4fa0bd2c2adbfe077f58395c18a72f5cbf89532743e3bddf43bc7aba706b0b74]
+description = 'Devnet Spot CHZ/USDC'
+base = 8
+quote = 6
+min_price_tick_size = 0.000001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100000000
+min_display_quantity_tick_size = 1
+
+[0x2021159081a88c9a627c66f770fb60c7be78d492509c89b203e1829d0413995a]
+description = 'Devnet Spot ETHBTCTrend/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000000
+min_display_quantity_tick_size = 0.01
+
+[0xfad0838bf6be7467c6a00d61360f7924afc848e4d0c56cc4261f94e77e124e7a]
+description = 'Devnet Spot USDC/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
+
+[0xba3101edf6cb94d0b29fd95fb1679f84fe981a98da91a3df1e06809845fab209]
+description = 'Devnet Spot WBTC/INJ'
+base = 18
+quote = 18
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
+
+[0xefc8e0b5bdb799010c9584c59fa14e759009d86c04fa52e0e67b411309096ace]
+description = 'Devnet Spot PROJ/INJ'
+base = 18
+quote = 18
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
 
 [0x1422a13427d5eabd4d8de7907c8340f7e58cb15553a9fd4ad5c90406561886f9]
-description = 'devnet Derivative COMP/USDT PERP'
+description = 'Devnet Derivative COMP/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
+
+[0x1c284820f24dff4c60fecd521a9df3df9c745d23dd585d45bf418653c2d73ab4]
+description = 'Devnet Derivative SNX/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
+
+[0x1f73e21972972c69c03fb105a5864592ac2b47996ffea3c500d1ea2d20138717]
+description = 'Devnet Derivative LINK/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
+
+[0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce]
+description = 'Devnet Derivative BTC/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
 
 [0x7cc8b10d7deb61e744ef83bdec2bbcf4a056867e89b062c6a453020ca82bd4e4]
-description = 'devnet Derivative INJ/USDT PERP'
+description = 'Devnet Derivative INJ/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
 
-[0xc60c2ba4c11976e4c10ed7c1f5ca789b63282d0b3782ec3d7fc29dec9f43415e]
-description = 'devnet Derivative STX/USDT PERP'
+[0x56d0c0293c4415e2d48fc2c8503a56a0c7389247396a2ef9b0a48c01f0646705]
+description = 'Devnet Derivative ATOM/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.100000
-min_display_quantity_tick_size = 0.1000
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.01
+min_display_quantity_tick_size = 0.01
 
-[0x8158e603fb80c4e417696b0e98765b4ca89dcf886d3b9b2b90dc15bfb1aebd51]
-description = 'devnet Derivative LUNA/UST PERP'
+[0x979731deaaf17d26b2e256ad18fecd0ac742b3746b9ea5382bac9bd0b5e58f74]
+description = 'Devnet Derivative ETH/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.100000
-min_display_quantity_tick_size = 0.1000
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
 
-[0x3400e8d1c785b00edc28c08e9671135830f9a52198944d27850c7818c46c3a3a]
-description = 'devnet Derivative ETH/USDT PERP BAND'
+[0xb64332daa987dcb200c26965bc9adaf8aa301fe3a0aecb0232fadbd3dfccd0d8]
+description = 'Devnet Derivative UNI/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
 
-[0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced]
-description = 'devnet Derivative BNB/USDT PERP'
+[0xccd6723224cae013827668ad1e7f361cde694adbb7a87f62a6d547cc464ba9b5]
+description = 'Devnet Derivative GRT/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
+
+[0x3b7fb1d9351f7fa2e6e0e5a11b3639ee5e0486c33a6a74f629c3fc3c3043efd5]
+description = 'Devnet Derivative BONK/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0000000001
+min_quantity_tick_size = 0.1
+min_display_quantity_tick_size = 0.1
+
+[AAVE]
+peggy_denom = peggy0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9
+decimals = 18
+
+[APE]
+peggy_denom = peggy0x4d224452801ACEd8B2F0aebE155379bb5D594381
+decimals = 18
+
+[ATOM]
+peggy_denom = ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
+decimals = 6
+
+[BNB]
+peggy_denom = peggy0xB8c77482e45F1F44dE1745F52C74426C631bDD52
+decimals = 18
+
+[CHZ]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6kpxy6ar5lkxqudjvryarrrttmakwsvzkvcyh
+decimals = 8
+
+[ETHBTCTrend]
+peggy_denom = peggy0x6b7f87279982d919Bbf85182DDeAB179B366D8f2
+decimals = 18
+
+[GF]
+peggy_denom = peggy0xAaEf88cEa01475125522e117BFe45cF32044E238
+decimals = 18
+
+[INJ]
+peggy_denom = inj
+decimals = 18
+
+[LINK]
+peggy_denom = peggy0x514910771AF9Ca656af840dff83E8264EcF986CA
+decimals = 18
+
+[MATIC]
+peggy_denom = peggy0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0
+decimals = 18
+
+[PROJ]
+peggy_denom = proj
+decimals = 18
+
+[SOMM]
+peggy_denom = ibc/34346A60A95EB030D62D6F5BDD4B745BE18E8A693372A8A347D5D53DBBB1328B
+decimals = 6
+
+[USC Coin (Wormhole from Ethereum)]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk
+decimals = 6
+
+[USD Coin]
+peggy_denom = factory/inj1hdvy6tl89llqy3ze8lv6mz5qh66sx9enn0jxg6/inj12sqy9uzzl3h3vqxam7sz9f0yvmhampcgesh3qw
+decimals = 6
+
+[USDC]
+peggy_denom = peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+decimals = 6
 
 [USDT]
 peggy_denom = peggy0xdAC17F958D2ee523a2206206994597C13D831ec7
-decimals = 
+decimals = 6
 
-[UST]
-peggy_denom = ibc/B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C
-decimals = 
+[WBTC]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku
+decimals = 18
 
+[WETH]
+peggy_denom = peggy0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+decimals = 18
+
+[YFI]
+peggy_denom = peggy0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e
+decimals = 18

--- a/client/metadata/assets/mainnet.ini
+++ b/client/metadata/assets/mainnet.ini
@@ -201,18 +201,9 @@ description = 'Mainnet Spot GF/USDT'
 base = 18
 quote = 6
 min_price_tick_size = 0.0000000000000001
-min_display_price_tick_size = 0.001
+min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 1000000000000000
 min_display_quantity_tick_size = 0.001
-
-[0x0f1a11df46d748c2b20681273d9528021522c6a0db00de4684503bbd53bef16e]
-description = 'Mainnet Spot UST/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.0001
-min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 10000
-min_display_quantity_tick_size = 0.01
 
 [0xdce84d5e9c4560b549256f34583fb4ed07c82026987451d5da361e6e238287b3]
 description = 'Mainnet Spot LUNA/UST'
@@ -223,8 +214,26 @@ min_display_price_tick_size = 0.00000001
 min_quantity_tick_size = 100000
 min_display_quantity_tick_size = 0.1
 
+[0x0f1a11df46d748c2b20681273d9528021522c6a0db00de4684503bbd53bef16e]
+description = 'Mainnet Spot UST/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 10000
+min_display_quantity_tick_size = 0.01
+
 [0xfbc729e93b05b4c48916c1433c9f9c2ddb24605a73483303ea0f87a8886b52af]
 description = 'Mainnet Spot INJ/UST'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
+
+[0xd7487c1fc78fdb283d838fa562339db0ca05cd4af57c6a20e6561f260c78d1ae]
+description = 'Mainnet Spot XBX/USDT'
 base = 18
 quote = 6
 min_price_tick_size = 0.000000000000001
@@ -237,9 +246,9 @@ description = 'Mainnet Spot HUAHUA/USDT'
 base = 6
 quote = 6
 min_price_tick_size = 0.000001
-min_display_price_tick_size = 1.0
+min_display_price_tick_size = 0.000001
 min_quantity_tick_size = 100000000
-min_display_quantity_tick_size = 100.0
+min_display_quantity_tick_size = 100
 
 [0x572f05fd93a6c2c4611b2eba1a0a36e102b6a592781956f0128a27662d84f112]
 description = 'Mainnet Spot APE/USDT'
@@ -277,6 +286,78 @@ min_display_price_tick_size = 0.01
 min_quantity_tick_size = 100000000
 min_display_quantity_tick_size = 0.01
 
+[0xabc20971099f5df5d1de138f8ea871e7e9832e3b0b54b61056eae15b09fed678]
+description = 'Mainnet Spot USDC/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000000
+min_display_quantity_tick_size = 1
+
+[0xcd4b823ad32db2245b61bf498936145d22cdedab808d2f9d65100330da315d29]
+description = 'Mainnet Spot STRD/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
+
+[0x4807e9ac33c565b4278fb9d288bd79546abbf5a368dfc73f160fe9caa37a70b1]
+description = 'Mainnet Spot axlUSDC/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000000
+min_display_quantity_tick_size = 1
+
+[0xe03df6e1571acb076c3d8f22564a692413b6843ad2df67411d8d8e56449c7ff4]
+description = 'Mainnet Spot CRE/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
+
+[0x219b522871725d175f63d5cb0a55e95aa688b1c030272c5ae967331e45620032]
+description = 'Mainnet Spot SteadyETH/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000000
+min_display_quantity_tick_size = 0.01
+
+[0x510855ccf9148b47c6114e1c9e26731f9fd68a6f6dbc5d148152d02c0f3e5ce0]
+description = 'Mainnet Spot SteadyBTC/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000000
+min_display_quantity_tick_size = 0.01
+
+[0x2021159081a88c9a627c66f770fb60c7be78d492509c89b203e1829d0413995a]
+description = 'Mainnet Spot ETHBTCTrend/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000000
+min_display_quantity_tick_size = 0.01
+
+[0x0686357b934c761784d58a2b8b12618dfe557de108a220e06f8f6580abb83aab]
+description = 'Mainnet Spot SOMM/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000000
+min_display_quantity_tick_size = 1
+
 [0x84ba79ffde31db8273a9655eb515cb6cadfdf451b8f57b83eb3f78dca5bbbe6d]
 description = 'Mainnet Spot SOL/USDC'
 base = 8
@@ -311,32 +392,14 @@ quote = 6
 min_price_tick_size = 0.0001
 min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 100
-min_display_quantity_tick_size = 100.0
-
-[0xcd4b823ad32db2245b61bf498936145d22cdedab808d2f9d65100330da315d29]
-description = 'Mainnet Spot STRD/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.0001
-min_display_price_tick_size = 1e-09
-min_quantity_tick_size = 1000
-min_display_quantity_tick_size = 1000.0
-
-[0x0686357b934c761784d58a2b8b12618dfe557de108a220e06f8f6580abb83aab]
-description = 'Mainnet Spot SOMM/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.0001
-min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 1000000
-min_display_quantity_tick_size = 10.0
+min_display_quantity_tick_size = 0.0001
 
 [0x4fa0bd2c2adbfe077f58395c18a72f5cbf89532743e3bddf43bc7aba706b0b74]
 description = 'Mainnet Spot CHZ/USDC'
 base = 8
 quote = 6
 min_price_tick_size = 0.000001
-min_display_price_tick_size = 1e-04
+min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 100000000
 min_display_quantity_tick_size = 1
 
@@ -347,14 +410,14 @@ quote = 6
 min_price_tick_size = 0.0000000000000001
 min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 10000000000000000000
-min_display_quantity_tick_size = 10.0
+min_display_quantity_tick_size = 10
 
-[0xe03df6e1571acb076c3d8f22564a692413b6843ad2df67411d8d8e56449c7ff4]
-description = 'Mainnet Spot CRE/USDT'
+[0x7fce43f1140df2e5f16977520629e32a591939081b59e8fbc1e1c4ddfa77a044]
+description = 'Mainnet Spot LDO/USDC'
 base = 6
-quote = 6
-min_price_tick_size = 0.0001
-min_display_price_tick_size = 0.0001
+quote = 8
+min_price_tick_size = 0.1
+min_display_price_tick_size = 0.001
 min_quantity_tick_size = 1000
 min_display_quantity_tick_size = 0.001
 
@@ -366,6 +429,15 @@ min_price_tick_size = 0.00001
 min_display_price_tick_size = 0.001
 min_quantity_tick_size = 100000
 min_display_quantity_tick_size = 0.001
+
+[0x4b29b6df99d73920acdc56962050786ac950fcdfec6603094b63cd38cad5197e]
+description = 'Mainnet Spot PUG/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.0000000000000001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100000000000000
+min_display_quantity_tick_size = 0.0001
 
 [0x1bba49ea1eb64958a19b66c450e241f17151bc2e5ea81ed5e2793af45598b906]
 description = 'Mainnet Spot ARB/USDT'
@@ -394,14 +466,14 @@ min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 10000000
 min_display_quantity_tick_size = 0.1
 
-[0xe8fe754e16233754e2811c36aca89992e35951cfd61376f1cbdc44be6ac8d3fb]
-description = 'Mainnet Spot NEOK/USDT'
+[0xce1829d4942ed939580e72e66fd8be3502396fc840b6d12b2d676bdb86542363]
+description = 'Mainnet Spot stINJ/INJ'
 base = 18
-quote = 6
-min_price_tick_size = 0.0000000000000001
-min_display_price_tick_size = 9.999999999999999e-05
-min_quantity_tick_size = 100000000000000000
-min_display_quantity_tick_size = 0.1
+quote = 18
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
 [0xa04adeed0f09ed45c73b344b520d05aa31eabe2f469dcbb02a021e0d9d098715]
 description = 'Mainnet Spot ORAI/USDT'
@@ -412,6 +484,15 @@ min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 100000
 min_display_quantity_tick_size = 0.1
 
+[0xe8fe754e16233754e2811c36aca89992e35951cfd61376f1cbdc44be6ac8d3fb]
+description = 'Mainnet Spot NEOK/USDT'
+base = 18
+quote = 6
+min_price_tick_size = 0.0000000000000001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100000000000000000
+min_display_quantity_tick_size = 0.1
+
 [0x2d8b2a2bef3782b988e16a8d718ea433d6dfebbb3b932975ca7913589cb408b5]
 description = 'Mainnet Spot KAVA/USDT'
 base = 6
@@ -419,14 +500,14 @@ quote = 6
 min_price_tick_size = 0.0001
 min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 1000000
-min_display_quantity_tick_size = 0.1
+min_display_quantity_tick_size = 1
 
 [0xbf94d932d1463959badee52ffbeb2eeeeeda750e655493e909ced540c375a277]
 description = 'Mainnet Spot USDTkv/USDT'
 base = 6
 quote = 6
 min_price_tick_size = 0.0001
-min_display_price_tick_size = 9.999999999999999e-05
+min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 100000
 min_display_quantity_tick_size = 0.1
 
@@ -435,16 +516,25 @@ description = 'Mainnet Spot TIA/USDT'
 base = 6
 quote = 6
 min_price_tick_size = 0.001
-min_display_price_tick_size = 9.999999999999999e-05
+min_display_price_tick_size = 0.001
 min_quantity_tick_size = 100000
 min_display_quantity_tick_size = 0.1
+
+[0x21f3eed62ddc64458129c0dcbff32b3f54c92084db787eb5cf7c20e69a1de033]
+description = 'Mainnet Spot TALIS/USDT'
+base = 6
+quote = 6
+min_price_tick_size = 0.00001
+min_display_price_tick_size = 0.00001
+min_quantity_tick_size = 10000000
+min_display_quantity_tick_size = 10
 
 [0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce]
 description = 'Mainnet Derivative BTC/USDT PERP'
 base = 0
 quote = 6
 min_price_tick_size = 1000000
-min_display_price_tick_size = 1.0
+min_display_price_tick_size = 1
 min_quantity_tick_size = 0.0001
 min_display_quantity_tick_size = 0.0001
 
@@ -475,15 +565,6 @@ min_display_price_tick_size = 0.001
 min_quantity_tick_size = 0.001
 min_display_quantity_tick_size = 0.001
 
-[0x8158e603fb80c4e417696b0e98765b4ca89dcf886d3b9b2b90dc15bfb1aebd51]
-description = 'Mainnet Derivative LUNA/UST PERP'
-base = 0
-quote = 6
-min_price_tick_size = 0.01
-min_display_price_tick_size = 0.00000001
-min_quantity_tick_size = 0.1
-min_display_quantity_tick_size = 0.1
-
 [0xc559df216747fc11540e638646c384ad977617d6d8f0ea5ffdfc18d52e58ab01]
 description = 'Mainnet Derivative ATOM/USDT PERP'
 base = 0
@@ -492,24 +573,6 @@ min_price_tick_size = 1000
 min_display_price_tick_size = 0.001
 min_quantity_tick_size = 0.01
 min_display_quantity_tick_size = 0.01
-
-[0xc60c2ba4c11976e4c10ed7c1f5ca789b63282d0b3782ec3d7fc29dec9f43415e]
-description = 'Mainnet Derivative STX/USDT PERP'
-base = 0
-quote = 6
-min_price_tick_size = 100
-min_display_price_tick_size = 0.001
-min_quantity_tick_size = 0.1
-min_display_quantity_tick_size = 0.1
-
-[0x2d1fc1ebff7cae29d6f85d3a2bb7f3f6f2bab12a25d6cc2834bcb06d7b08fd74]
-description = 'Mainnet Derivative BAYC/WETH PERP'
-base = 0
-quote = 18
-min_price_tick_size = 100000000000000
-min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 0.0001
-min_display_quantity_tick_size = 0.0001
 
 [0x8c7fd5e6a7f49d840512a43d95389a78e60ebaf0cde1af86b26a785eb23b3be5]
 description = 'Mainnet Derivative OSMO/UST PERP'
@@ -543,7 +606,7 @@ description = 'Mainnet Derivative BONK/USDT PERP'
 base = 0
 quote = 6
 min_price_tick_size = 0.0001
-min_display_price_tick_size = 1e-10
+min_display_price_tick_size = 0.0000000001
 min_quantity_tick_size = 0.1
 min_display_quantity_tick_size = 0.1
 
@@ -574,24 +637,6 @@ min_display_price_tick_size = 0.0001
 min_quantity_tick_size = 0.1
 min_display_quantity_tick_size = 0.1
 
-[0x64c3a57b693ede854b0a2794ed5c99546925d1fbe74d91a2e3286e4155a00dee]
-description = 'Mainnet Derivative TIA/USDT-30NOV2023 PERP'
-base = 0
-quote = 6
-min_price_tick_size = 1000
-min_display_price_tick_size = 0.001
-min_quantity_tick_size = 0.1
-min_display_quantity_tick_size = 0.1
-
-[0x4fe7aff4dd27be7cbb924336e7fe2d160387bb1750811cf165ce58d4c612aebb]
-description = 'Mainnet Derivative AXL/USDT PERP'
-base = 0
-quote = 6
-min_price_tick_size = 100
-min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 1
-min_display_quantity_tick_size = 0.1
-
 [0x332230109e7afb839b4750d4cf961666b608071ecb64dac55662dac37529639e]
 description = 'Mainnet Derivative BTC/USDTkv PERP'
 base = 0
@@ -608,159 +653,109 @@ quote = 6
 min_price_tick_size = 100000
 min_display_price_tick_size = 0.1
 min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0x4fe7aff4dd27be7cbb924336e7fe2d160387bb1750811cf165ce58d4c612aebb]
+description = 'Mainnet Derivative AXL/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1
+min_display_quantity_tick_size = 1
+
+[0x64c3a57b693ede854b0a2794ed5c99546925d1fbe74d91a2e3286e4155a00dee]
+description = 'Mainnet Derivative TIA/USDT-30NOV2023'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.1
 min_display_quantity_tick_size = 0.1
-
-[WETH]
-peggy_denom = peggy0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
-decimals = 18
-
-[USDC]
-peggy_denom = peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
-decimals = 6
-
-[INJ]
-peggy_denom = inj
-decimals = 18
-
-[USDT]
-peggy_denom = peggy0xdAC17F958D2ee523a2206206994597C13D831ec7
-decimals = 6
-
-[LINK]
-peggy_denom = peggy0x514910771AF9Ca656af840dff83E8264EcF986CA
-decimals = 18
 
 [AAVE]
 peggy_denom = peggy0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9
 decimals = 18
 
-[MATIC]
-peggy_denom = peggy0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0
+[APE]
+peggy_denom = peggy0x4d224452801ACEd8B2F0aebE155379bb5D594381
 decimals = 18
 
-[UNI]
-peggy_denom = peggy0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
-decimals = 18
-
-[SUSHI]
-peggy_denom = peggy0x6B3595068778DD592e39A122f4f5a5cF09C90fE2
-decimals = 18
-
-[GRT]
-peggy_denom = peggy0xc944E90C64B2c07662A292be6244BDf05Cda44a7
-decimals = 18
-
-[SNX]
-peggy_denom = peggy0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F
-decimals = 18
-
-[QNT]
-peggy_denom = peggy0x4a220E6096B25EADb88358cb44068A3248254675
-decimals = 18
-
-[WBTC]
-peggy_denom = peggy0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599
+[ARB]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1d5vz0uzwlpfvgwrwulxg6syy82axa58y4fuszd
 decimals = 8
-
-[AXS]
-peggy_denom = peggy0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b
-decimals = 18
 
 [ATOM]
 peggy_denom = ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
 decimals = 6
 
-[GF]
-peggy_denom = peggy0xAaEf88cEa01475125522e117BFe45cF32044E238
+[AXS]
+peggy_denom = peggy0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b
 decimals = 18
 
-[UST]
-peggy_denom = ibc/B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C
-decimals = 6
-
-[LUNA]
-peggy_denom = ibc/B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395
-decimals = 6
-
-[APE]
-peggy_denom = peggy0x4d224452801ACEd8B2F0aebE155379bb5D594381
+[CANTO]
+peggy_denom = ibc/D91A2C4EE7CD86BBAFCE0FA44A60DDD9AFBB7EEB5B2D46C0984DEBCC6FEDFAE8
 decimals = 18
 
-[PUG]
-peggy_denom = peggy0xf9a06dE3F6639E6ee4F079095D5093644Ad85E8b
-decimals = 18
+[CHZ]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6kpxy6ar5lkxqudjvryarrrttmakwsvzkvcyh
+decimals = 8
 
-[HUAHUA]
-peggy_denom = ibc/E7807A46C0B7B44B350DA58F51F278881B863EC4DCA94635DAB39E52C30766CB
-decimals = 6
-
-[EVMOS]
-peggy_denom = ibc/16618B7F7AC551F48C057A13F4CA5503693FBFF507719A85BC6876B8BD75F821
-decimals = 18
-
-[XPRT]
-peggy_denom = ibc/B786E7CBBF026F6F15A8DA248E0F18C62A0F7A70CB2DABD9239398C8B5150ABB
+[CRE]
+peggy_denom = ibc/3A6DD3358D9F7ADD18CDE79BA10B400511A5DE4AE2C037D7C9639B52ADAF35C6
 decimals = 6
 
 [DOT]
 peggy_denom = ibc/624BA9DD171915A2B9EA70F69638B2CEA179959850C1A586F6C485498F29EDD4
 decimals = 10
 
-[SteadyETH]
-peggy_denom = peggy0x3F07A84eCdf494310D397d24c1C78B041D2fa622
+[ETHBTCTrend]
+peggy_denom = peggy0x6b7f87279982d919Bbf85182DDeAB179B366D8f2
 decimals = 18
 
-[SteadyBTC]
-peggy_denom = peggy0x4986fD36b6b16f49b43282Ee2e24C5cF90ed166d
+[EVMOS]
+peggy_denom = ibc/16618B7F7AC551F48C057A13F4CA5503693FBFF507719A85BC6876B8BD75F821
 decimals = 18
 
-[SOMM]
-peggy_denom = ibc/34346A60A95EB030D62D6F5BDD4B745BE18E8A693372A8A347D5D53DBBB1328B
-decimals = 6
-
-[STRD]
-peggy_denom = ibc/3FDD002A3A4019B05A33D324B2F29748E77AF501BEA5C96D1F28B2D6755F9F25
-decimals = 6
-
-[SOL]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1sthrn5ep8ls5vzz8f9gp89khhmedahhdkqa8z3
-decimals = 8
-
-[CHZ]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6kpxy6ar5lkxqudjvryarrrttmakwsvzkvcyh
-decimals = 8
-
-[USDCso]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj12pwnhtv7yat2s30xuf4gdk9qm85v4j3e60dgvu
-decimals = 6
-
-[USDCet]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk
-decimals = 6
-
-[CANTO]
-peggy_denom = ibc/D91A2C4EE7CD86BBAFCE0FA44A60DDD9AFBB7EEB5B2D46C0984DEBCC6FEDFAE8
+[GF]
+peggy_denom = peggy0xAaEf88cEa01475125522e117BFe45cF32044E238
 decimals = 18
 
-[CRE]
-peggy_denom = ibc/3A6DD3358D9F7ADD18CDE79BA10B400511A5DE4AE2C037D7C9639B52ADAF35C6
+[GRT]
+peggy_denom = peggy0xc944E90C64B2c07662A292be6244BDf05Cda44a7
+decimals = 18
+
+[HUAHUA]
+peggy_denom = ibc/E7807A46C0B7B44B350DA58F51F278881B863EC4DCA94635DAB39E52C30766CB
+decimals = 6
+
+[INJ]
+peggy_denom = inj
+decimals = 18
+
+[KAVA]
+peggy_denom = ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205
 decimals = 6
 
 [LDO]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk
+decimals = 6
+
+[LINK]
+peggy_denom = peggy0x514910771AF9Ca656af840dff83E8264EcF986CA
+decimals = 18
+
+[LUNA]
+peggy_denom = ibc/B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395
+decimals = 6
+
+[Lido DAO]
 peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1me6t602jlndzxgv2d7ekcnkjuqdp7vfh4txpyy
 decimals = 8
 
-[ARB]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1d5vz0uzwlpfvgwrwulxg6syy82axa58y4fuszd
-decimals = 8
-
-[WMATIC]
-peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1dxv423h8ygzgxmxnvrf33ws3k94aedfdevxd8h
-decimals = 8
-
-[NBLA]
-peggy_denom = factory/inj1d0zfq42409a5mhdagjutl8u6u9rgcm4h8zfmfq/nbla
-decimals = 6
+[MATIC]
+peggy_denom = peggy0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0
+decimals = 18
 
 [NEOK]
 peggy_denom = ibc/F6CC233E5C0EA36B1F74AB1AF98471A2D6A80E2542856639703E908B4D93E7C4
@@ -770,14 +765,106 @@ decimals = 18
 peggy_denom = ibc/C20C0A822BD22B2CEF0D067400FCCFB6FAEEE9E91D360B4E0725BD522302D565
 decimals = 6
 
-[KAVA]
-peggy_denom = ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205
+[PUG]
+peggy_denom = peggy0xf9a06dE3F6639E6ee4F079095D5093644Ad85E8b
+decimals = 18
+
+[QNT]
+peggy_denom = peggy0x4a220E6096B25EADb88358cb44068A3248254675
+decimals = 18
+
+[SNX]
+peggy_denom = peggy0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F
+decimals = 18
+
+[SOL]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1sthrn5ep8ls5vzz8f9gp89khhmedahhdkqa8z3
+decimals = 8
+
+[SOMM]
+peggy_denom = ibc/34346A60A95EB030D62D6F5BDD4B745BE18E8A693372A8A347D5D53DBBB1328B
+decimals = 6
+
+[STRD]
+peggy_denom = ibc/3FDD002A3A4019B05A33D324B2F29748E77AF501BEA5C96D1F28B2D6755F9F25
+decimals = 6
+
+[SUSHI]
+peggy_denom = peggy0x6B3595068778DD592e39A122f4f5a5cF09C90fE2
+decimals = 18
+
+[SteadyBTC]
+peggy_denom = peggy0x4986fD36b6b16f49b43282Ee2e24C5cF90ed166d
+decimals = 18
+
+[SteadyETH]
+peggy_denom = peggy0x3F07A84eCdf494310D397d24c1C78B041D2fa622
+decimals = 18
+
+[TALIS]
+peggy_denom = factory/inj1maeyvxfamtn8lfyxpjca8kuvauuf2qeu6gtxm3/Talis
+decimals = 6
+
+[TIA]
+peggy_denom = ibc/F51BB221BAA275F2EBF654F70B005627D7E713AFFD6D86AFD1E43CAA886149F4
+decimals = 6
+
+[UNI]
+peggy_denom = peggy0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+decimals = 18
+
+[USC Coin (Wormhole from Ethereum)]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk
+decimals = 6
+
+[USDC]
+peggy_denom = peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+decimals = 6
+
+[USDCet]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk
+decimals = 6
+
+[USDCso]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj12pwnhtv7yat2s30xuf4gdk9qm85v4j3e60dgvu
+decimals = 6
+
+[USDT]
+peggy_denom = peggy0xdAC17F958D2ee523a2206206994597C13D831ec7
 decimals = 6
 
 [USDTkv]
 peggy_denom = ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB
 decimals = 6
 
-[TIA]
-peggy_denom = ibc/F51BB221BAA275F2EBF654F70B005627D7E713AFFD6D86AFD1E43CAA886149F4
+[UST]
+peggy_denom = ibc/B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C
 decimals = 6
+
+[WBTC]
+peggy_denom = peggy0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599
+decimals = 8
+
+[WETH]
+peggy_denom = peggy0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+decimals = 18
+
+[WMATIC]
+peggy_denom = factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1dxv423h8ygzgxmxnvrf33ws3k94aedfdevxd8h
+decimals = 8
+
+[XBX]
+peggy_denom = peggy0x080B12E80C9b45e97C23b6ad10a16B3e2a123949
+decimals = 18
+
+[XPRT]
+peggy_denom = ibc/B786E7CBBF026F6F15A8DA248E0F18C62A0F7A70CB2DABD9239398C8B5150ABB
+decimals = 6
+
+[axlUSDC]
+peggy_denom = ibc/7E1AF94AD246BE522892751046F0C959B768642E5671CC3742264068D49553C0
+decimals = 6
+
+[stINJ]
+peggy_denom = ibc/AC87717EA002B0123B10A05063E69BCA274BA2C44D842AEEB41558D2856DCE93
+decimals = 18

--- a/client/metadata/assets/testnet.ini
+++ b/client/metadata/assets/testnet.ini
@@ -1,426 +1,397 @@
-[0x01e920e081b6f3b2e5183399d5b6733bb6f80319e6be3805b95cb7236910ff0e]
-description = 'testnet Spot WETH/USDC'
+[0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe]
+description = 'Testnet Spot INJ/USDT'
 base = 18
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0x01edfab47f124748dc89998eb33144af734484ba07099014594321729a0ca16b]
-description = 'testnet Spot AAVE/USDT'
+[0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0]
+description = 'Testnet Spot APE/USDT'
 base = 18
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa]
-description = 'testnet Spot ATOM/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.010000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 10000.000000
-min_display_quantity_tick_size = 0.0100
-
-[0x09cc2c28fbedbdd677e07924653f8f583d0ee5886e74046e7f114210d990784b]
-description = 'testnet Spot UNI/USDC'
+[0xabed4a28baf4617bd4e04e4d71157c45ff6f95f181dee557aae59b4d1009aa97]
+description = 'Testnet Spot INJ/APE'
 base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
+quote = 18
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.000000000000001
+min_quantity_tick_size = 1000000000000000000
+min_display_quantity_tick_size = 1
 
-[0x0c9f98c99b23e89dbf6a60bec05372790b39e03da0f86dd0208fc8e28751bd8c]
-description = 'testnet Spot SUSHI/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0x0f1a11df46d748c2b20681273d9528021522c6a0db00de4684503bbd53bef16e]
-description = 'testnet Spot UST/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.000100000000000000
-min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 10000.000000
-min_display_quantity_tick_size = 0.0100
-
-[0x170a06eb653548f67e94b0fcb82c5258c83b0a2b62ed24c55749d5ac77bc7621]
-description = 'testnet Spot WBTC/USDC'
+[0xa97182f11f1aa5339c7f4c3fe3cc1c69b39079f11b864c86d912956c5c2db75c]
+description = 'Testnet Spot WETH/USDT'
 base = 8
 quote = 6
-min_price_tick_size = 0.000100000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 10000.000000
-min_display_quantity_tick_size = 0.0001
+min_price_tick_size = 0.00001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 100000
+min_display_quantity_tick_size = 0.001
 
-[0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31]
-description = 'testnet Spot LINK/USDT'
-base = 18
+[0x1c315bd2cfcc769a8d8eca49ce7b1bc5fb0353bfcb9fa82895fe0c1c2a62306e]
+description = 'Testnet Spot WBTC/USDT'
+base = 8
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.00001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 100000
+min_display_quantity_tick_size = 0.001
 
-[0x28f3c9897e23750bf653889224f93390c467b83c86d736af79431958fff833d1]
-description = 'testnet Spot MATIC/USDT'
-base = 18
+[0x491ee4fae7956dd72b6a97805046ffef65892e1d3254c559c18056a519b2ca15]
+description = 'Testnet Spot ATOM/USDT'
+base = 8
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
+min_price_tick_size = 0.00001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 100000
+min_display_quantity_tick_size = 0.001
 
-[0x29255e99290ff967bc8b351ce5b1cb08bc76a9a9d012133fb242bdf92cd28d89]
-description = 'testnet Spot GRT/USDT'
-base = 18
+[0xf88816466c4bdd77b3ac5d0eaf6c1d2547b2aa48a0ab5bffe81502d642209262]
+description = 'Testnet Spot WBTC/USDC'
+base = 8
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0x51092ddec80dfd0d41fee1a7d93c8465de47cd33966c8af8ee66c14fe341a545]
-description = 'testnet Spot SNX/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0x5abfffe9079d53e0bf8ee9b3064b427acc3d71d6ba58a44235abe38f60115678]
-description = 'testnet Spot MATIC/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0x7471d361b90fc8541267bd088f498c2a461a2c0c57ff2b9a08279480e803b470]
-description = 'testnet Spot AXS/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000010000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 10000000000000000.000000
-min_display_quantity_tick_size = 0.0100
-
-[0x7f71c4fba375c964be8db7fc7a5275d974f8c6cdc4d758f2ac4997f106bb052b]
-description = 'testnet Spot GF/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0x8b1a4d3e8f6b559e30e40922ee3662dd78edf7042330d4d620d188699d1a9715]
-description = 'testnet Spot USDT/USDC'
-base = 6
-quote = 6
-min_price_tick_size = 0.000100000000000000
+min_price_tick_size = 0.000001
 min_display_price_tick_size = 0.0001
-min_quantity_tick_size = 100.000000
-min_display_quantity_tick_size = 0.0001
-
-[0x9a629b947b6f946af4f6076cfda67f3535d73ee3cef6176cf6d9c8d6b0a03f37]
-description = 'testnet Spot SUSHI/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xa43d2be9861efb0d188b136cef0ae2150f80e08ec318392df654520dd359fcd7]
-description = 'testnet Spot GRT/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0]
-description = 'testnet Spot INJ/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xbe9d4a0a768c7e8efb6740be76af955928f93c247e0b3a1a106184c6cf3216a7]
-description = 'testnet Spot QNT/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xcdfbfaf1f24055e89b3c7cc763b8cb46ffff08cdc38c999d01f58d64af75dca9]
-description = 'testnet Spot AAVE/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xd1956e20d74eeb1febe31cd37060781ff1cb266f49e0512b446a5fafa9a16034]
-description = 'testnet Spot WETH/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xdce84d5e9c4560b549256f34583fb4ed07c82026987451d5da361e6e238287b3]
-description = 'testnet Spot LUNA/UST'
-base = 6
-quote = 6
-min_price_tick_size = 0.010000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 100000.000000
-min_display_quantity_tick_size = 0.1000
-
-[0xe0dc13205fb8b23111d8555a6402681965223135d368eeeb964681f9ff12eb2a]
-description = 'testnet Spot INJ/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xe8bf0467208c24209c1cf0fd64833fa43eb6e8035869f9d043dbff815ab76d01]
-description = 'testnet Spot UNI/USDT'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xfbc729e93b05b4c48916c1433c9f9c2ddb24605a73483303ea0f87a8886b52af]
-description = 'testnet Spot INJ/UST'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xfe93c19c0a072c8dd208b96694e024305a7dff01bbf12cac2bfa81b246c69040]
-description = 'testnet Spot LINK/USDC'
-base = 18
-quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 1000000000000000.000000
-min_display_quantity_tick_size = 0.0010
-
-[0xa283fc94a9055a01a58bb6229b1e56a8bb54069a0debfce7fbd1e6c25a95330c]
-description = 'Testnet Spot TIA/USDT'
-base = 6
-quote = 6
-min_price_tick_size = 0.001
-min_display_price_tick_size = 1e-05
-min_quantity_tick_size = 0.001
+min_quantity_tick_size = 10000000
 min_display_quantity_tick_size = 0.1
 
-[0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced]
-description = 'testnet Derivative BNB/USDT PERP'
-base = 0
+[0xfad0838bf6be7467c6a00d61360f7924afc848e4d0c56cc4261f94e77e124e7a]
+description = 'Testnet Spot USDC/USDT'
+base = 6
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000000
+min_display_quantity_tick_size = 1
 
-[0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce]
-description = 'testnet Derivative BTC/USDT PERP'
-base = 0
+[0x5fbd22eb44d9db413513f99ceb9a5ac4cc5b5e6893d5882877391d6927927e6d]
+description = 'Testnet Spot USDC/USDT'
+base = 6
 quote = 6
-min_price_tick_size = 100000.000000000000000000
-min_display_price_tick_size = 0.1000
-min_quantity_tick_size = 0.000100
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100
 min_display_quantity_tick_size = 0.0001
 
-[0x54d4505adef6a5cef26bc403a33d595620ded4e15b9e2bc3dd489b714813366a]
-description = 'testnet Derivative ETH/USDT PERP'
-base = 0
+[0x37c5ffe6d1c2318a7b9efde1e82c1186d688c1c4a1ad41da9a0878d353f1c88b]
+description = 'Testnet Spot USDT/USDC'
+base = 6
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 0.001
 
-[0x8158e603fb80c4e417696b0e98765b4ca89dcf886d3b9b2b90dc15bfb1aebd51]
-description = 'testnet Derivative LUNA/UST PERP'
-base = 0
+[0x9354b951718f87e1ffcc11800ee5890eef45a7f05884e9a604722eb8a907d07d]
+description = 'Testnet Spot INJ/wBTC'
+base = 18
+quote = 8
+min_price_tick_size = 0.000000000000001
+min_display_price_tick_size = 0.00001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
+
+[0x2d92a74f1526c600c0913edd2c38e3ec2ffc5e458842f2cf83545528d5e51d0d]
+description = 'Testnet Spot INJ/wETH'
+base = 18
+quote = 8
+min_price_tick_size = 0.00000000000001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100000000000000
+min_display_quantity_tick_size = 0.0001
+
+[0xab5811fe4fa18b221216f01891775313310cfe85ea749f31bd0d2c58754710f4]
+description = 'Testnet Spot INJ/wETH'
+base = 8
+quote = 8
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 10000
+min_display_quantity_tick_size = 0.0001
+
+[0x4ca031b7c8504fa2a8ee2fe6a47b78c7a8e01975c8c28e05029e07b2c5ec9ef5]
+description = 'Testnet Spot INJ/USDC'
+base = 18
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.100000
-min_display_quantity_tick_size = 0.1000
+min_price_tick_size = 0.0000000000000001
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 100000000000000
+min_display_quantity_tick_size = 0.0001
 
-[0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963]
-description = 'testnet Derivative INJ/USDT PERP'
-base = 0
-quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
-
-[0x8fbc64cb2a183625692adb6906152dff3d0f299f7a9092e74cb2429dc10de2aa]
-description = 'testnet Derivative FR FUT'
-base = 0
-quote = 6
-min_price_tick_size = 1000.000000000000000000
-min_display_price_tick_size = 0.0010
-min_quantity_tick_size = 0.001000
-min_display_quantity_tick_size = 0.0010
-
-[0x2d1fc1ebff7cae29d6f85d3a2bb7f3f6f2bab12a25d6cc2834bcb06d7b08fd74]
-description = 'testnet Derivative BAYC/WETH PERP'
-base = 0
+[0xf3298cc12f12945c9da877766d320e4056e5dfd7d3c38208a0ef2f525f7ca0a2]
+description = 'Testnet Spot APE/INJ'
+base = 18
 quote = 18
-min_price_tick_size = 10000000000000000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 1000000000000000
+min_display_quantity_tick_size = 0.001
 
-[0xfb5f14852bd01af901291dd2aa65e997b3a831f957124a7fe7aa40d218ff71ae]
-description = 'testnet Derivative XAG/USDT PERP'
+[0x263f7922659fa5b0ecb756a2dd8bf8e2aab9fe8d9ce375f7075d6e6d87b6f95d]
+description = 'Testnet Spot INJ'
+base = 8
+quote = 18
+min_price_tick_size = 100000000
+min_display_price_tick_size = 0.01
+min_quantity_tick_size = 10000000
+min_display_quantity_tick_size = 0.1
+
+[0xba7096c2c49b845e6bfc8317e88831c15786bee3149836dde55481abd5ef040b]
+description = 'Testnet Spot MITOTEST1/INJ'
+base = 18
+quote = 18
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
+
+[0xf02752c2c87728af7fd10a298a8a645261859eafd0295dcda7e2c5b45c8412cf]
+description = 'Testnet Spot stINJ/INJ'
+base = 18
+quote = 18
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
+
+[0xd7a9fbff264246244d6e4afd7ec926aedc4c8f49118967f241126f47c5b44177]
+description = 'Testnet Spot PROJ/INJ'
+base = 18
+quote = 18
+min_price_tick_size = 0.001
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 10000000000000
+min_display_quantity_tick_size = 0.00001
+
+[0x2e94326a421c3f66c15a3b663c7b1ab7fb6a5298b3a57759ecf07f0036793fc9]
+description = 'Testnet Derivative BTC/USDT PERP Pyth'
 base = 0
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 10000
+min_display_price_tick_size = 0.01
+min_quantity_tick_size = 0.01
+min_display_quantity_tick_size = 0.01
 
-[0x71f9040a42eda0117e00251242b49b1d6c3fe133bfe6ec181a660f8ddff74ead]
-description = 'testnet Derivative XAU/USDT PERP'
+[0x95698a9d8ba11660f44d7001d8c6fb191552ece5d9141a05c5d9128711cdc2e0]
+description = 'Testnet Derivative SOL/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.010000
-min_display_quantity_tick_size = 0.0100
+min_price_tick_size = 10000
+min_display_price_tick_size = 0.01
+min_quantity_tick_size = 0.01
+min_display_quantity_tick_size = 0.01
 
-[0xcf18525b53e54ad7d27477426ade06d69d8d56d2f3bf35fe5ce2ad9eb97c2fbc]
-description = 'testnet Derivative OSMO/USDT PERP'
+[0x820bad0e0cbee65bb0eea5a99c78720c97b7b2217c47dcc0e0875e1ebb35e546]
+description = 'Testnet Derivative ARB/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 10000.000000000000000000
-min_display_price_tick_size = 0.0100
-min_quantity_tick_size = 0.100000
-min_display_quantity_tick_size = 0.1000
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.1
+min_display_quantity_tick_size = 0.1
 
-[0xe1142d8041f76bbcedc10214425c7019a9e886b6d56e82b28befc191bb775c45]
-description = 'testnet Derivative Frontrunner Futures: Expires 3.15.2023'
+[0x155576f660b3b6116c1ab7a42fbf58a95adf11b3061f88f81bc8df228e7ac934]
+description = 'Testnet Derivative XAU/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0000
-min_quantity_tick_size = 0.000100
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
 min_display_quantity_tick_size = 0.0001
 
-[0x265a73ffd132e26d42b61015d119f18aa9f95577fa9f2c0e78992aaf8468c3ca]
-description = 'testnet Derivative Frontrunner Futures: Expires 4.28.2022'
+[0xb6fd8f78b97238eb67146e9b097c131e94730c10170cbcafa82ea2fd14ff62c7]
+description = 'Testnet Derivative EUR/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 0.000000000000001000
-min_display_price_tick_size = 0.0000
-min_quantity_tick_size = 0.000100
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
 min_display_quantity_tick_size = 0.0001
+
+[0xba9c96a1a9cc226cfe6bd9bca3a433e396569d1955393f38f2ee728cfda7ec58]
+description = 'Testnet Derivative JPY/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0xe185b08a7ccd830a94060edd5e457d30f429aa6f0757f75a8b93aa611780cfac]
+description = 'Testnet Derivative GBP/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0x0f03542809143c7e5d3c22f56bc6e51eb2c8bab5009161b58f6f468432dfa196]
+description = 'Testnet Derivative XAG/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0x70bc8d7feab38b23d5fdfb12b9c3726e400c265edbcbf449b6c80c31d63d3a02]
+description = 'Testnet Derivative ETH/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0xd97d0da6f6c11710ef06315971250e4e9aed4b7d4cd02059c9477ec8cf243782]
+description = 'Testnet Derivative ATOM/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6]
+description = 'Testnet Derivative INJ/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0xc10e8b25979a1620a6e088ce4c141f5fd2841e2089d4c99b6e5cd8f85986dcd3]
+description = 'Testnet Derivative PEPE/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1
+min_display_price_tick_size = 0.000001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 1000
+
+[0x27f586c9911507c75bf604df00735b871119c5234f8e52bc54fbd54729588a0e]
+description = 'Testnet Derivative 1000PEPE/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1
+min_display_price_tick_size = 0.000001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 1000
+
+[0x14f82598b92674598af196770a45e1b808a4ef3aa86eb9ca09aff1aeab33ac46]
+description = 'Testnet Derivative 1MPEPE/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100
+min_display_price_tick_size = 0.0001
+min_quantity_tick_size = 1
+min_display_quantity_tick_size = 1
+
+[0xa12df259e07f9194389362153b42d8eb12368de5e22668d5f9fc3ac34dd43d18]
+description = 'Testnet Derivative 1MPEPE/USDT'
+base = 0
+quote = 6
+min_price_tick_size = 1
+min_display_price_tick_size = 0.000001
+min_quantity_tick_size = 1000
+min_display_quantity_tick_size = 1000
+
+[0x8f002b45cb287a4c3ecb89174ee42a7e933178d89c7eea94dbed8dc5dfd35d23]
+description = 'Testnet Derivative GOLD/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 100000
+min_display_price_tick_size = 0.1
+min_quantity_tick_size = 0.0001
+min_display_quantity_tick_size = 0.0001
+
+[0x707fb74431a16c71e54d5cd2301daff1a464e1a854c0fef4bca3fe6c0a5b47d1]
+description = 'Testnet Derivative TRUCPI/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.1
+min_display_quantity_tick_size = 0.1
+
+[0xdfbb038abf614c59decdaaa02c0446bbebcd16327bd4e9d0350a1e3b691a38ef]
+description = 'Testnet Derivative EVINDEX/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.1
+min_display_quantity_tick_size = 0.1
+
+[0xf97a740538e10845e0c3db9ea94c6eaf8a570aeebe3e3511e2e387501a40e4bb]
+description = 'Testnet Derivative TIA/USDT-01NOV2023'
+base = 0
+quote = 6
+min_price_tick_size = 0.0001
+min_display_price_tick_size = 0.0000000001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
+
+[APE]
+peggy_denom = peggy0x44C21afAaF20c270EBbF5914Cfc3b5022173FEB7
+decimals = 18
 
 [ATOM]
-peggy_denom = ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
-decimals = 6
-
-[SUSHI]
-peggy_denom = peggy0x6B3595068778DD592e39A122f4f5a5cF09C90fE2
-decimals = 18
-
-[LINK]
-peggy_denom = peggy0x514910771AF9Ca656af840dff83E8264EcF986CA
-decimals = 18
-
-[UST]
-peggy_denom = ibc/B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C
-decimals = 
-
-[WBTC]
-peggy_denom = peggy0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/atom
 decimals = 8
 
-[AXS]
-peggy_denom = peggy0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b
-decimals = 18
-
-[WETH]
-peggy_denom = peggy0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
-decimals = 
-
-[AAVE]
-peggy_denom = peggy0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9
-decimals = 18
-
-[USDT]
-peggy_denom = peggy0xdAC17F958D2ee523a2206206994597C13D831ec7
-decimals = 
-
-[MATIC]
-peggy_denom = peggy0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0
-decimals = 18
-
-[GRT]
-peggy_denom = peggy0xc944E90C64B2c07662A292be6244BDf05Cda44a7
-decimals = 18
+[Cosmos]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/atom
+decimals = 8
 
 [INJ]
 peggy_denom = inj
 decimals = 18
 
+[MITOTEST1]
+peggy_denom = factory/inj17gkuet8f6pssxd8nycm3qr9d9y699rupv6397z/mitotest1
+decimals = 18
+
+[PROJ]
+peggy_denom = factory/inj17gkuet8f6pssxd8nycm3qr9d9y699rupv6397z/proj
+decimals = 18
+
+[USD Coin]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/usdc
+decimals = 6
+
 [USDC]
-peggy_denom = peggy0x514910771AF9Ca656af840dff83E8264EcF986CA
+peggy_denom = factory/inj1hdvy6tl89llqy3ze8lv6mz5qh66sx9enn0jxg6/inj12sqy9uzzl3h3vqxam7sz9f0yvmhampcgesh3qw
 decimals = 6
 
-[UNI]
-peggy_denom = peggy0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
-decimals = 18
-
-[SNX]
-peggy_denom = peggy0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F
-decimals = 18
-
-[GF]
-peggy_denom = peggy0xAaEf88cEa01475125522e117BFe45cF32044E238
-decimals = 18
-
-[QNT]
-peggy_denom = peggy0x4a220E6096B25EADb88358cb44068A3248254675
-decimals = 18
-
-[LUNA]
-peggy_denom = ibc/B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395
+[USDT]
+peggy_denom = peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5
 decimals = 6
 
-[TIA]
-peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/tia
-decimals = 6
+[WBTC]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/wbtc
+decimals = 8
+
+[WETH]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/weth
+decimals = 8
+
+[stINJ]
+peggy_denom = factory/inj17gkuet8f6pssxd8nycm3qr9d9y699rupv6397z/stinj
+decimals = 18
+
+[wBTC]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/wbtc
+decimals = 8
+
+[wETH]
+peggy_denom = factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/weth
+decimals = 8

--- a/client/metadata/fetch_metadata.go
+++ b/client/metadata/fetch_metadata.go
@@ -27,10 +27,10 @@ var metadataTemplate = `[%s]
 description = '%s %s %s'
 base = %d
 quote = %d
-min_price_tick_size = %.18f
-min_display_price_tick_size = %.4f
-min_quantity_tick_size = %f
-min_display_quantity_tick_size = %.4f
+min_price_tick_size = %s
+min_display_price_tick_size = %s
+min_quantity_tick_size = %s
+min_display_quantity_tick_size = %s
 
 `
 var symbolTemplate = `[%s]
@@ -80,10 +80,10 @@ func FetchDenom(network common.Network) {
 			network.Name, "Spot", m.Ticker,
 			m.BaseTokenMeta.Decimals,
 			m.QuoteTokenMeta.Decimals,
-			minPriceTickSize,
-			minDisplayPriceTickSize,
-			minQuantityTickSize,
-			minDisplayQuantityTickSize,
+			strconv.FormatFloat(minPriceTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minDisplayPriceTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minQuantityTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minDisplayQuantityTickSize, 'f', -1, 64),
 		)
 		metadataOutput += config
 	}
@@ -117,10 +117,10 @@ func FetchDenom(network common.Network) {
 			network.Name, "Derivative", m.Ticker,
 			0,
 			m.QuoteTokenMeta.Decimals,
-			minPriceTickSize,
-			minDisplayPriceTickSize,
-			minQuantityTickSize,
-			minQuantityTickSize,
+			strconv.FormatFloat(minPriceTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minDisplayPriceTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minQuantityTickSize, 'f', -1, 64),
+			strconv.FormatFloat(minQuantityTickSize, 'f', -1, 64),
 		)
 		metadataOutput += config
 	}

--- a/examples/exchange/derivatives/12_Trades/example.go
+++ b/examples/exchange/derivatives/12_Trades/example.go
@@ -7,29 +7,28 @@ import (
 
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
+	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
 )
 
 func main() {
-	//network := common.LoadNetwork("mainnet", "k8s")
 	network := common.LoadNetwork("testnet", "lb")
 	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	ctx := context.Background()
-	marketId := "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0"
-	subaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+	marketId := "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce"
+	subaccountId := "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
 
-	req := spotExchangePB.TradesRequest{
+	req := derivativeExchangePB.TradesRequest{
 		MarketId:     marketId,
 		SubaccountId: subaccountId,
 	}
 
-	res, err := exchangeClient.GetSpotTrades(ctx, req)
+	res, err := exchangeClient.GetDerivativeTrades(ctx, req)
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	str, _ := json.MarshalIndent(res, "", " ")

--- a/examples/exchange/derivatives/7_StreamOrderbookUpdate/example.go
+++ b/examples/exchange/derivatives/7_StreamOrderbookUpdate/example.go
@@ -18,7 +18,7 @@ type MapOrderbook struct {
 
 func main() {
 	network := common.LoadNetwork("devnet-1", "")
-	exchangeClient, err := exchangeclient.NewExchangeClient(network.ExchangeGrpcEndpoint)
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		fmt.Println(err)
 		panic(err)

--- a/examples/exchange/spot/6_Trades/example.go
+++ b/examples/exchange/spot/6_Trades/example.go
@@ -7,28 +7,28 @@ import (
 
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
+	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
 )
 
 func main() {
 	network := common.LoadNetwork("testnet", "lb")
 	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 
 	ctx := context.Background()
-	marketId := "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce"
-	subaccountId := "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
+	marketId := "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0"
+	subaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
 
-	req := derivativeExchangePB.TradesRequest{
+	req := spotExchangePB.TradesRequest{
 		MarketId:     marketId,
 		SubaccountId: subaccountId,
 	}
 
-	res, err := exchangeClient.GetDerivativeTrades(ctx, req)
+	res, err := exchangeClient.GetSpotTrades(ctx, req)
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 
 	str, _ := json.MarshalIndent(res, "", " ")


### PR DESCRIPTION
- Changed fetch_metadata script to ensure numbers are writen with the less amount of possible decimal 0. 
- Synchronized markets and tokens INI files afterwards for mainnet, testnet and devnet
- Fixed an issue in the example scripts to get trades for derivative and spot markets. The example for spot was under the derivatives folder and vice versa.