### PR TITLE
Feat/initialize tokens from chain denoms

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client/core"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"math"
 	"os"
 	"strconv"
@@ -86,8 +87,18 @@ type ChainClient interface {
 	AsyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastTxResponse, error)
 	QueueBroadcastMsg(msgs ...sdk.Msg) error
 
+	// Bank Module
 	GetBankBalances(ctx context.Context, address string) (*banktypes.QueryAllBalancesResponse, error)
 	GetBankBalance(ctx context.Context, address string, denom string) (*banktypes.QueryBalanceResponse, error)
+	GetBankSpendableBalances(ctx context.Context, address string, pagination *query.PageRequest) (*banktypes.QuerySpendableBalancesResponse, error)
+	GetBankSpendableBalancesByDenom(ctx context.Context, address string, denom string) (*banktypes.QuerySpendableBalanceByDenomResponse, error)
+	GetBankTotalSupply(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryTotalSupplyResponse, error)
+	GetBankSupplyOf(ctx context.Context, denom string) (*banktypes.QuerySupplyOfResponse, error)
+	GetDenomMetadata(ctx context.Context, denom string) (*banktypes.QueryDenomMetadataResponse, error)
+	GetDenomsMetadata(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryDenomsMetadataResponse, error)
+	GetDenomOwners(ctx context.Context, denom string, pagination *query.PageRequest) (*banktypes.QueryDenomOwnersResponse, error)
+	GetBankSendEnabled(ctx context.Context, denoms []string, pagination *query.PageRequest) (*banktypes.QuerySendEnabledResponse, error)
+
 	GetAuthzGrants(ctx context.Context, req authztypes.QueryGrantsRequest) (*authztypes.QueryGrantsResponse, error)
 	GetAccount(ctx context.Context, address string) (*authtypes.QueryAccountResponse, error)
 
@@ -448,18 +459,13 @@ func (c *chainClient) Close() {
 	}
 }
 
+//Bank Module
+
 func (c *chainClient) GetBankBalances(ctx context.Context, address string) (*banktypes.QueryAllBalancesResponse, error) {
 	req := &banktypes.QueryAllBalancesRequest{
 		Address: address,
 	}
 	return c.bankQueryClient.AllBalances(ctx, req)
-}
-
-func (c *chainClient) GetAccount(ctx context.Context, address string) (*authtypes.QueryAccountResponse, error) {
-	req := &authtypes.QueryAccountRequest{
-		Address: address,
-	}
-	return c.authQueryClient.Account(ctx, req)
 }
 
 func (c *chainClient) GetBankBalance(ctx context.Context, address string, denom string) (*banktypes.QueryBalanceResponse, error) {
@@ -468,6 +474,67 @@ func (c *chainClient) GetBankBalance(ctx context.Context, address string, denom 
 		Denom:   denom,
 	}
 	return c.bankQueryClient.Balance(ctx, req)
+}
+
+func (c *chainClient) GetBankSpendableBalances(ctx context.Context, address string, pagination *query.PageRequest) (*banktypes.QuerySpendableBalancesResponse, error) {
+	req := &banktypes.QuerySpendableBalancesRequest{
+		Address:    address,
+		Pagination: pagination,
+	}
+	return c.bankQueryClient.SpendableBalances(ctx, req)
+}
+
+func (c *chainClient) GetBankSpendableBalancesByDenom(ctx context.Context, address string, denom string) (*banktypes.QuerySpendableBalanceByDenomResponse, error) {
+	req := &banktypes.QuerySpendableBalanceByDenomRequest{
+		Address: address,
+		Denom:   denom,
+	}
+	return c.bankQueryClient.SpendableBalanceByDenom(ctx, req)
+}
+
+func (c *chainClient) GetBankTotalSupply(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryTotalSupplyResponse, error) {
+	req := &banktypes.QueryTotalSupplyRequest{Pagination: pagination}
+	return c.bankQueryClient.TotalSupply(ctx, req)
+}
+
+func (c *chainClient) GetBankSupplyOf(ctx context.Context, denom string) (*banktypes.QuerySupplyOfResponse, error) {
+	req := &banktypes.QuerySupplyOfRequest{Denom: denom}
+	return c.bankQueryClient.SupplyOf(ctx, req)
+}
+
+func (c *chainClient) GetDenomMetadata(ctx context.Context, denom string) (*banktypes.QueryDenomMetadataResponse, error) {
+	req := &banktypes.QueryDenomMetadataRequest{Denom: denom}
+	return c.bankQueryClient.DenomMetadata(ctx, req)
+}
+
+func (c *chainClient) GetDenomsMetadata(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryDenomsMetadataResponse, error) {
+	req := &banktypes.QueryDenomsMetadataRequest{Pagination: pagination}
+	return c.bankQueryClient.DenomsMetadata(ctx, req)
+}
+
+func (c *chainClient) GetDenomOwners(ctx context.Context, denom string, pagination *query.PageRequest) (*banktypes.QueryDenomOwnersResponse, error) {
+	req := &banktypes.QueryDenomOwnersRequest{
+		Denom:      denom,
+		Pagination: pagination,
+	}
+	return c.bankQueryClient.DenomOwners(ctx, req)
+}
+
+func (c *chainClient) GetBankSendEnabled(ctx context.Context, denoms []string, pagination *query.PageRequest) (*banktypes.QuerySendEnabledResponse, error) {
+	req := &banktypes.QuerySendEnabledRequest{
+		Denoms:     denoms,
+		Pagination: pagination,
+	}
+	return c.bankQueryClient.SendEnabled(ctx, req)
+}
+
+// Auth Module
+
+func (c *chainClient) GetAccount(ctx context.Context, address string) (*authtypes.QueryAccountResponse, error) {
+	req := &authtypes.QueryAccountRequest{
+		Address: address,
+	}
+	return c.authQueryClient.Account(ctx, req)
 }
 
 // SyncBroadcastMsg sends Tx to chain and waits until Tx is included in block.

--- a/client/chain/chain_test.go
+++ b/client/chain/chain_test.go
@@ -1,11 +1,8 @@
 package chain
 
 import (
-	"context"
 	"github.com/InjectiveLabs/sdk-go/client"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cosmtypes "github.com/cosmos/cosmos-sdk/types"
@@ -42,21 +39,9 @@ func createClient(senderAddress cosmtypes.AccAddress, cosmosKeyring keyring.Keyr
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := NewChainClientWithMarketsAssistant(
+	chainClient, err := NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/client/chain/chain_test_support.go
+++ b/client/chain/chain_test_support.go
@@ -1,0 +1,240 @@
+package chain
+
+import (
+	"context"
+	"errors"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
+	chainstreamtypes "github.com/InjectiveLabs/sdk-go/chain/stream/types"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	eth "github.com/ethereum/go-ethereum/common"
+	"google.golang.org/grpc"
+	"time"
+)
+
+type MockChainClient struct {
+	DenomsMetadataResponses []*banktypes.QueryDenomsMetadataResponse
+}
+
+func (c *MockChainClient) CanSignTransactions() bool {
+	return true
+}
+
+func (c *MockChainClient) FromAddress() sdk.AccAddress {
+	return sdk.AccAddress{}
+}
+
+func (c *MockChainClient) QueryClient() *grpc.ClientConn {
+	return &grpc.ClientConn{}
+}
+
+func (c *MockChainClient) ClientContext() client.Context {
+	return client.Context{}
+}
+
+func (c *MockChainClient) GetAccNonce() (accNum uint64, accSeq uint64) {
+	return 1, 2
+}
+
+func (c *MockChainClient) SimulateMsg(clientCtx client.Context, msgs ...sdk.Msg) (*txtypes.SimulateResponse, error) {
+	return &txtypes.SimulateResponse{}, nil
+}
+
+func (c *MockChainClient) AsyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
+	return &txtypes.BroadcastTxResponse{}, nil
+}
+
+func (c *MockChainClient) SyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
+	return &txtypes.BroadcastTxResponse{}, nil
+}
+
+func (c *MockChainClient) BuildSignedTx(clientCtx client.Context, accNum, accSeq, initialGas uint64, msg ...sdk.Msg) ([]byte, error) {
+	return *new([]byte), nil
+}
+
+func (c *MockChainClient) SyncBroadcastSignedTx(tyBytes []byte) (*txtypes.BroadcastTxResponse, error) {
+	return &txtypes.BroadcastTxResponse{}, nil
+}
+
+func (c *MockChainClient) AsyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastTxResponse, error) {
+	return &txtypes.BroadcastTxResponse{}, nil
+}
+
+func (c *MockChainClient) QueueBroadcastMsg(msgs ...sdk.Msg) error {
+	return nil
+}
+
+func (c *MockChainClient) GetBankBalances(ctx context.Context, address string) (*banktypes.QueryAllBalancesResponse, error) {
+	return &banktypes.QueryAllBalancesResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankBalance(ctx context.Context, address string, denom string) (*banktypes.QueryBalanceResponse, error) {
+	return &banktypes.QueryBalanceResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankSpendableBalances(ctx context.Context, address string, pagination *query.PageRequest) (*banktypes.QuerySpendableBalancesResponse, error) {
+	return &banktypes.QuerySpendableBalancesResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankSpendableBalancesByDenom(ctx context.Context, address string, denom string) (*banktypes.QuerySpendableBalanceByDenomResponse, error) {
+	return &banktypes.QuerySpendableBalanceByDenomResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankTotalSupply(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryTotalSupplyResponse, error) {
+	return &banktypes.QueryTotalSupplyResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankSupplyOf(ctx context.Context, denom string) (*banktypes.QuerySupplyOfResponse, error) {
+	return &banktypes.QuerySupplyOfResponse{}, nil
+}
+
+func (c *MockChainClient) GetDenomMetadata(ctx context.Context, denom string) (*banktypes.QueryDenomMetadataResponse, error) {
+	return &banktypes.QueryDenomMetadataResponse{}, nil
+}
+
+func (c *MockChainClient) GetDenomsMetadata(ctx context.Context, pagination *query.PageRequest) (*banktypes.QueryDenomsMetadataResponse, error) {
+	var response *banktypes.QueryDenomsMetadataResponse
+	var localError error
+	if len(c.DenomsMetadataResponses) > 0 {
+		response = c.DenomsMetadataResponses[0]
+		c.DenomsMetadataResponses = c.DenomsMetadataResponses[1:]
+		localError = nil
+	} else {
+		response = &banktypes.QueryDenomsMetadataResponse{}
+		localError = errors.New("there are no responses configured")
+	}
+
+	return response, localError
+}
+
+func (c *MockChainClient) GetDenomOwners(ctx context.Context, denom string, pagination *query.PageRequest) (*banktypes.QueryDenomOwnersResponse, error) {
+	return &banktypes.QueryDenomOwnersResponse{}, nil
+}
+
+func (c *MockChainClient) GetBankSendEnabled(ctx context.Context, denoms []string, pagination *query.PageRequest) (*banktypes.QuerySendEnabledResponse, error) {
+	return &banktypes.QuerySendEnabledResponse{}, nil
+}
+
+func (c *MockChainClient) GetAuthzGrants(ctx context.Context, req authztypes.QueryGrantsRequest) (*authztypes.QueryGrantsResponse, error) {
+	return &authztypes.QueryGrantsResponse{}, nil
+}
+
+func (c *MockChainClient) GetAccount(ctx context.Context, address string) (*authtypes.QueryAccountResponse, error) {
+	return &authtypes.QueryAccountResponse{}, nil
+}
+
+func (c *MockChainClient) BuildGenericAuthz(granter string, grantee string, msgtype string, expireIn time.Time) *authztypes.MsgGrant {
+	return &authztypes.MsgGrant{}
+}
+
+func (c *MockChainClient) BuildExchangeAuthz(granter string, grantee string, authzType ExchangeAuthz, subaccountId string, markets []string, expireIn time.Time) *authztypes.MsgGrant {
+	return &authztypes.MsgGrant{}
+}
+
+func (c *MockChainClient) BuildExchangeBatchUpdateOrdersAuthz(
+	granter string,
+	grantee string,
+	subaccountId string,
+	spotMarkets []string,
+	derivativeMarkets []string,
+	expireIn time.Time,
+) *authztypes.MsgGrant {
+	return &authztypes.MsgGrant{}
+}
+
+func (c *MockChainClient) DefaultSubaccount(acc sdk.AccAddress) eth.Hash {
+	return eth.HexToHash("")
+}
+
+func (c *MockChainClient) Subaccount(account sdk.AccAddress, index int) eth.Hash {
+	return eth.HexToHash("")
+}
+
+func (c *MockChainClient) GetSubAccountNonce(ctx context.Context, subaccountId eth.Hash) (*exchangetypes.QuerySubaccountTradeNonceResponse, error) {
+	return &exchangetypes.QuerySubaccountTradeNonceResponse{}, nil
+}
+
+func (c *MockChainClient) GetFeeDiscountInfo(ctx context.Context, account string) (*exchangetypes.QueryFeeDiscountAccountInfoResponse, error) {
+	return &exchangetypes.QueryFeeDiscountAccountInfoResponse{}, nil
+}
+
+func (c *MockChainClient) UpdateSubaccountNonceFromChain() error {
+	return nil
+}
+
+func (c *MockChainClient) SynchronizeSubaccountNonce(subaccountId eth.Hash) error {
+	return nil
+}
+
+func (c *MockChainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, derivativeOrders []exchangetypes.DerivativeOrder, subaccountId eth.Hash) (OrderHashes, error) {
+	return OrderHashes{}, nil
+}
+
+func (c *MockChainClient) SpotOrder(defaultSubaccountID eth.Hash, network common.Network, d *SpotOrderData) *exchangetypes.SpotOrder {
+	return c.CreateSpotOrder(defaultSubaccountID, network, d, MarketsAssistant{})
+}
+
+func (c *MockChainClient) CreateSpotOrder(defaultSubaccountID eth.Hash, network common.Network, d *SpotOrderData, marketsAssistant MarketsAssistant) *exchangetypes.SpotOrder {
+	return &exchangetypes.SpotOrder{}
+}
+
+func (c *MockChainClient) DerivativeOrder(defaultSubaccountID eth.Hash, network common.Network, d *DerivativeOrderData) *exchangetypes.DerivativeOrder {
+	return c.CreateDerivativeOrder(defaultSubaccountID, network, d, MarketsAssistant{})
+}
+
+func (c *MockChainClient) CreateDerivativeOrder(defaultSubaccountID eth.Hash, network common.Network, d *DerivativeOrderData, marketAssistant MarketsAssistant) *exchangetypes.DerivativeOrder {
+	return &exchangetypes.DerivativeOrder{}
+}
+
+func (c *MockChainClient) OrderCancel(defaultSubaccountID eth.Hash, d *OrderCancelData) *exchangetypes.OrderData {
+	return &exchangetypes.OrderData{}
+}
+
+func (c *MockChainClient) SmartContractState(
+	ctx context.Context,
+	contractAddress string,
+	queryData []byte,
+) (*wasmtypes.QuerySmartContractStateResponse, error) {
+	return &wasmtypes.QuerySmartContractStateResponse{}, nil
+}
+
+func (c *MockChainClient) RawContractState(
+	ctx context.Context,
+	contractAddress string,
+	queryData []byte,
+) (*wasmtypes.QueryRawContractStateResponse, error) {
+	return &wasmtypes.QueryRawContractStateResponse{}, nil
+}
+
+func (c *MockChainClient) GetGasFee() (string, error) {
+	return "", nil
+}
+
+func (c *MockChainClient) StreamEventOrderFail(sender string, failEventCh chan map[string]uint) {}
+
+func (c *MockChainClient) StreamEventOrderFailWithWebsocket(sender string, websocket *rpchttp.HTTP, failEventCh chan map[string]uint) {
+}
+
+func (c *MockChainClient) StreamOrderbookUpdateEvents(orderbookType OrderbookType, marketIds []string, orderbookCh chan exchangetypes.Orderbook) {
+}
+
+func (c *MockChainClient) StreamOrderbookUpdateEventsWithWebsocket(orderbookType OrderbookType, marketIds []string, websocket *rpchttp.HTTP, orderbookCh chan exchangetypes.Orderbook) {
+}
+
+func (c *MockChainClient) ChainStream(ctx context.Context, req chainstreamtypes.StreamRequest) (chainstreamtypes.Stream_StreamClient, error) {
+	return nil, nil
+}
+
+func (c *MockChainClient) GetTx(ctx context.Context, txHash string) (*txtypes.GetTxResponse, error) {
+	return &txtypes.GetTxResponse{}, nil
+}
+
+func (c *MockChainClient) Close() {}

--- a/client/chain/markets_assistant_test_support.go
+++ b/client/chain/markets_assistant_test_support.go
@@ -1,0 +1,159 @@
+package chain
+
+import (
+	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
+	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func createINJTokenMeta() spotExchangePB.TokenMeta {
+	return spotExchangePB.TokenMeta{
+		Name:      "Injective Protocol",
+		Address:   "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+		Symbol:    "INJ",
+		Logo:      "https://static.alchemyapi.io/images/assets/7226.png",
+		Decimals:  18,
+		UpdatedAt: 1681739137644,
+	}
+}
+
+func createAPETokenMeta() spotExchangePB.TokenMeta {
+	return spotExchangePB.TokenMeta{
+		Name:      "APE",
+		Address:   "0x0000000000000000000000000000000000000000",
+		Symbol:    "APE",
+		Logo:      "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
+		Decimals:  18,
+		UpdatedAt: 1681739137646,
+	}
+}
+
+func createUSDTTokenMeta() spotExchangePB.TokenMeta {
+	return spotExchangePB.TokenMeta{
+		Name:      "USDT",
+		Address:   "0x0000000000000000000000000000000000000000",
+		Symbol:    "USDT",
+		Logo:      "https://static.alchemyapi.io/images/assets/825.png",
+		Decimals:  6,
+		UpdatedAt: 1681739137645,
+	}
+}
+
+func createUSDTPerpTokenMeta() derivativeExchangePB.TokenMeta {
+	return derivativeExchangePB.TokenMeta{
+		Name:      "Tether",
+		Address:   "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		Symbol:    "USDTPerp",
+		Logo:      "https://static.alchemyapi.io/images/assets/825.png",
+		Decimals:  6,
+		UpdatedAt: 1683929869866,
+	}
+}
+
+func createINJUSDTSpotMarketInfo() spotExchangePB.SpotMarketInfo {
+	injTokenMeta := createINJTokenMeta()
+	usdtTokenMeta := createUSDTTokenMeta()
+	marketInfo := spotExchangePB.SpotMarketInfo{
+		MarketId:            "0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0",
+		MarketStatus:        "active",
+		Ticker:              "INJ/USDT",
+		BaseDenom:           "inj",
+		BaseTokenMeta:       &injTokenMeta,
+		QuoteDenom:          "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5",
+		QuoteTokenMeta:      &usdtTokenMeta,
+		MakerFeeRate:        "-0.0001",
+		TakerFeeRate:        "0.001",
+		ServiceProviderFee:  "0.4",
+		MinPriceTickSize:    "0.000000000000001",
+		MinQuantityTickSize: "1000000000000000",
+	}
+
+	return marketInfo
+}
+
+func createAPEUSDTSpotMarketInfo() spotExchangePB.SpotMarketInfo {
+	apeTokenMeta := createAPETokenMeta()
+	usdtTokenMeta := createUSDTTokenMeta()
+	marketInfo := spotExchangePB.SpotMarketInfo{
+		MarketId:            "0x8b67e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e000",
+		MarketStatus:        "active",
+		Ticker:              "APE/USDT",
+		BaseDenom:           "peggy0x44C21afAaF20c270EBbF5914Cfc3b5022173FEB7",
+		BaseTokenMeta:       &apeTokenMeta,
+		QuoteDenom:          "factory/peggy0x87aB3B4C8661e07D6372361211B96ed4Dc300000",
+		QuoteTokenMeta:      &usdtTokenMeta,
+		MakerFeeRate:        "-0.0001",
+		TakerFeeRate:        "0.001",
+		ServiceProviderFee:  "0.4",
+		MinPriceTickSize:    "0.000000000000001",
+		MinQuantityTickSize: "1000000000000000",
+	}
+
+	return marketInfo
+}
+
+func createBTCUSDTDerivativeMarketInfo() derivativeExchangePB.DerivativeMarketInfo {
+	usdtPerpTokenMeta := createUSDTPerpTokenMeta()
+
+	perpetualMarketInfo := derivativeExchangePB.PerpetualMarketInfo{
+		HourlyFundingRateCap: "0.0000625",
+		HourlyInterestRate:   "0.00000416666",
+		NextFundingTimestamp: 1684764000,
+		FundingInterval:      3600,
+	}
+
+	perpetualmarketFunding := derivativeExchangePB.PerpetualMarketFunding{
+		CumulativeFunding: "6880500093.266083891331674194",
+		CumulativePrice:   "-0.952642601240470199",
+		LastTimestamp:     1684763442,
+	}
+
+	marketInfo := derivativeExchangePB.DerivativeMarketInfo{
+		MarketId:               "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce",
+		MarketStatus:           "active",
+		Ticker:                 "BTC/USDT PERP",
+		OracleBase:             "BTC",
+		OracleQuote:            "USDT",
+		OracleType:             "bandibc",
+		OracleScaleFactor:      6,
+		InitialMarginRatio:     "0.095",
+		MaintenanceMarginRatio: "0.025",
+		QuoteDenom:             "peggy0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		QuoteTokenMeta:         &usdtPerpTokenMeta,
+		MakerFeeRate:           "-0.0001",
+		TakerFeeRate:           "0.001",
+		ServiceProviderFee:     "0.4",
+		IsPerpetual:            true,
+		MinPriceTickSize:       "1000000",
+		MinQuantityTickSize:    "0.0001",
+		PerpetualMarketInfo:    &perpetualMarketInfo,
+		PerpetualMarketFunding: &perpetualmarketFunding,
+	}
+
+	return marketInfo
+}
+
+func createSmartDenomMetadata() types.Metadata {
+	firstDenomUnit := types.DenomUnit{
+		Denom:    "factory/inj105ujajd95znwjvcy3hwcz80pgy8tc6v77spur0/SMART",
+		Exponent: 0,
+		Aliases:  []string{"microSMART"},
+	}
+	secondDenomUnit := types.DenomUnit{
+		Denom:    "SMART",
+		Exponent: 6,
+		Aliases:  []string{"SMART"},
+	}
+	metadata := types.Metadata{
+		Description: "SMART",
+		DenomUnits:  []*types.DenomUnit{&firstDenomUnit, &secondDenomUnit},
+		Base:        "factory/inj105ujajd95znwjvcy3hwcz80pgy8tc6v77spur0/SMART",
+		Display:     "SMART",
+		Name:        "SMART",
+		Symbol:      "SMART",
+		URI:         "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/2560px-Flag_of_the_People%27s_Republic_of_China.svg.png",
+		URIHash:     "",
+	}
+
+	return metadata
+}

--- a/client/exchange/exchange_test_support.go
+++ b/client/exchange/exchange_test_support.go
@@ -1,7 +1,8 @@
-package core
+package exchange
 
 import (
 	"context"
+	"errors"
 	accountPB "github.com/InjectiveLabs/sdk-go/exchange/accounts_rpc/pb"
 	auctionPB "github.com/InjectiveLabs/sdk-go/exchange/auction_rpc/pb"
 	derivativeExchangePB "github.com/InjectiveLabs/sdk-go/exchange/derivative_exchange_rpc/pb"
@@ -10,136 +11,8 @@ import (
 	oraclePB "github.com/InjectiveLabs/sdk-go/exchange/oracle_rpc/pb"
 	portfolioExchangePB "github.com/InjectiveLabs/sdk-go/exchange/portfolio_rpc/pb"
 	spotExchangePB "github.com/InjectiveLabs/sdk-go/exchange/spot_exchange_rpc/pb"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
-
-func createINJTokenMeta() spotExchangePB.TokenMeta {
-	return spotExchangePB.TokenMeta{
-		Name:      "Injective Protocol",
-		Address:   "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
-		Symbol:    "INJ",
-		Logo:      "https://static.alchemyapi.io/images/assets/7226.png",
-		Decimals:  18,
-		UpdatedAt: 1681739137644,
-	}
-}
-
-func createAPETokenMeta() spotExchangePB.TokenMeta {
-	return spotExchangePB.TokenMeta{
-		Name:      "APE",
-		Address:   "0x0000000000000000000000000000000000000000",
-		Symbol:    "APE",
-		Logo:      "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455",
-		Decimals:  18,
-		UpdatedAt: 1681739137646,
-	}
-}
-
-func createUSDTTokenMeta() spotExchangePB.TokenMeta {
-	return spotExchangePB.TokenMeta{
-		Name:      "USDT",
-		Address:   "0x0000000000000000000000000000000000000000",
-		Symbol:    "USDT",
-		Logo:      "https://static.alchemyapi.io/images/assets/825.png",
-		Decimals:  6,
-		UpdatedAt: 1681739137645,
-	}
-}
-
-func createUSDTPerpTokenMeta() derivativeExchangePB.TokenMeta {
-	return derivativeExchangePB.TokenMeta{
-		Name:      "Tether",
-		Address:   "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-		Symbol:    "USDTPerp",
-		Logo:      "https://static.alchemyapi.io/images/assets/825.png",
-		Decimals:  6,
-		UpdatedAt: 1683929869866,
-	}
-}
-
-func createINJUSDTSpotMarketInfo() spotExchangePB.SpotMarketInfo {
-	injTokenMeta := createINJTokenMeta()
-	usdtTokenMeta := createUSDTTokenMeta()
-	marketInfo := spotExchangePB.SpotMarketInfo{
-		MarketId:            "0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0",
-		MarketStatus:        "active",
-		Ticker:              "INJ/USDT",
-		BaseDenom:           "inj",
-		BaseTokenMeta:       &injTokenMeta,
-		QuoteDenom:          "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5",
-		QuoteTokenMeta:      &usdtTokenMeta,
-		MakerFeeRate:        "-0.0001",
-		TakerFeeRate:        "0.001",
-		ServiceProviderFee:  "0.4",
-		MinPriceTickSize:    "0.000000000000001",
-		MinQuantityTickSize: "1000000000000000",
-	}
-
-	return marketInfo
-}
-
-func createAPEUSDTSpotMarketInfo() spotExchangePB.SpotMarketInfo {
-	apeTokenMeta := createAPETokenMeta()
-	usdtTokenMeta := createUSDTTokenMeta()
-	marketInfo := spotExchangePB.SpotMarketInfo{
-		MarketId:            "0x8b67e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e000",
-		MarketStatus:        "active",
-		Ticker:              "APE/USDT",
-		BaseDenom:           "peggy0x44C21afAaF20c270EBbF5914Cfc3b5022173FEB7",
-		BaseTokenMeta:       &apeTokenMeta,
-		QuoteDenom:          "factory/peggy0x87aB3B4C8661e07D6372361211B96ed4Dc300000",
-		QuoteTokenMeta:      &usdtTokenMeta,
-		MakerFeeRate:        "-0.0001",
-		TakerFeeRate:        "0.001",
-		ServiceProviderFee:  "0.4",
-		MinPriceTickSize:    "0.000000000000001",
-		MinQuantityTickSize: "1000000000000000",
-	}
-
-	return marketInfo
-}
-
-func createBTCUSDTDerivativeMarketInfo() derivativeExchangePB.DerivativeMarketInfo {
-	usdtPerpTokenMeta := createUSDTPerpTokenMeta()
-
-	perpetualMarketInfo := derivativeExchangePB.PerpetualMarketInfo{
-		HourlyFundingRateCap: "0.0000625",
-		HourlyInterestRate:   "0.00000416666",
-		NextFundingTimestamp: 1684764000,
-		FundingInterval:      3600,
-	}
-
-	perpetualmarketFunding := derivativeExchangePB.PerpetualMarketFunding{
-		CumulativeFunding: "6880500093.266083891331674194",
-		CumulativePrice:   "-0.952642601240470199",
-		LastTimestamp:     1684763442,
-	}
-
-	marketInfo := derivativeExchangePB.DerivativeMarketInfo{
-		MarketId:               "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce",
-		MarketStatus:           "active",
-		Ticker:                 "BTC/USDT PERP",
-		OracleBase:             "BTC",
-		OracleQuote:            "USDT",
-		OracleType:             "bandibc",
-		OracleScaleFactor:      6,
-		InitialMarginRatio:     "0.095",
-		MaintenanceMarginRatio: "0.025",
-		QuoteDenom:             "peggy0xdAC17F958D2ee523a2206206994597C13D831ec7",
-		QuoteTokenMeta:         &usdtPerpTokenMeta,
-		MakerFeeRate:           "-0.0001",
-		TakerFeeRate:           "0.001",
-		ServiceProviderFee:     "0.4",
-		IsPerpetual:            true,
-		MinPriceTickSize:       "1000000",
-		MinQuantityTickSize:    "0.0001",
-		PerpetualMarketInfo:    &perpetualMarketInfo,
-		PerpetualMarketFunding: &perpetualmarketFunding,
-	}
-
-	return marketInfo
-}
 
 type MockExchangeClient struct {
 	SpotMarketsResponses       []spotExchangePB.MarketsResponse
@@ -196,6 +69,10 @@ func (e *MockExchangeClient) GetDerivativeMarkets(ctx context.Context, req deriv
 
 func (e *MockExchangeClient) GetDerivativePositions(ctx context.Context, req derivativeExchangePB.PositionsRequest) (derivativeExchangePB.PositionsResponse, error) {
 	return derivativeExchangePB.PositionsResponse{}, nil
+}
+
+func (e *MockExchangeClient) GetDerivativePositionsV2(ctx context.Context, req derivativeExchangePB.PositionsV2Request) (derivativeExchangePB.PositionsV2Response, error) {
+	return derivativeExchangePB.PositionsV2Response{}, nil
 }
 
 func (e *MockExchangeClient) GetDerivativeLiquidablePositions(ctx context.Context, req derivativeExchangePB.LiquidablePositionsRequest) (derivativeExchangePB.LiquidablePositionsResponse, error) {
@@ -399,6 +276,10 @@ func (e *MockExchangeClient) GetRedemptions(ctx context.Context, req insurancePB
 
 func (e *MockExchangeClient) GetAccountPortfolio(ctx context.Context, accountAddress string) (portfolioExchangePB.AccountPortfolioResponse, error) {
 	return portfolioExchangePB.AccountPortfolioResponse{}, nil
+}
+
+func (e *MockExchangeClient) GetAccountPortfolioBalances(ctx context.Context, accountAddress string) (portfolioExchangePB.AccountPortfolioBalancesResponse, error) {
+	return portfolioExchangePB.AccountPortfolioBalancesResponse{}, nil
 }
 
 func (e *MockExchangeClient) StreamAccountPortfolio(ctx context.Context, accountAddress string, subaccountId, balanceType string) (portfolioExchangePB.InjectivePortfolioRPC_StreamAccountPortfolioClient, error) {

--- a/examples/chain/0_LocalOrderHash/example.go
+++ b/examples/chain/0_LocalOrderHash/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -56,15 +55,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -75,24 +73,34 @@ func main() {
 	// prepare tx msg
 	defaultSubaccountID := chainClient.Subaccount(senderAddress, 1)
 
-	spotOrder := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY,
-		Quantity:     decimal.NewFromFloat(2),
-		Price:        decimal.NewFromFloat(22.55),
-		FeeRecipient: senderAddress.String(),
-		MarketId:     "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
-		Cid:          uuid.NewString(),
-	})
+	spotOrder := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY,
+			Quantity:     decimal.NewFromFloat(2),
+			Price:        decimal.NewFromFloat(22.55),
+			FeeRecipient: senderAddress.String(),
+			MarketId:     "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
-	derivativeOrder := chainClient.DerivativeOrder(defaultSubaccountID, network, &chainclient.DerivativeOrderData{
-		OrderType:    exchangetypes.OrderType_BUY,
-		Quantity:     decimal.NewFromFloat(2),
-		Price:        decimal.RequireFromString("31"),
-		Leverage:     decimal.RequireFromString("2.5"),
-		FeeRecipient: senderAddress.String(),
-		MarketId:     "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
-		Cid:          uuid.NewString(),
-	})
+	derivativeOrder := chainClient.CreateDerivativeOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.DerivativeOrderData{
+			OrderType:    exchangetypes.OrderType_BUY,
+			Quantity:     decimal.NewFromFloat(2),
+			Price:        decimal.RequireFromString("31"),
+			Leverage:     decimal.RequireFromString("2.5"),
+			FeeRecipient: senderAddress.String(),
+			MarketId:     "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgBatchCreateSpotLimitOrders)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/10_MsgBatchCancelDerivativeOrders/example.go
+++ b/examples/chain/10_MsgBatchCancelDerivativeOrders/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/11_MsgBatchCreateSpotLimitOrders/example.go
+++ b/examples/chain/11_MsgBatchCreateSpotLimitOrders/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -58,15 +57,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -81,14 +79,18 @@ func main() {
 	amount := decimal.NewFromFloat(2)
 	price := decimal.NewFromFloat(22.5)
 
-	order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     amount,
-		Price:        price,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     amount,
+			Price:        price,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant)
 	msg := new(exchangetypes.MsgBatchCreateSpotLimitOrders)
 	msg.Sender = senderAddress.String()
 	msg.Orders = []exchangetypes.SpotOrder{*order}

--- a/examples/chain/12_MsgBatchCreateDerivativeLimitOrders/example.go
+++ b/examples/chain/12_MsgBatchCreateDerivativeLimitOrders/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -58,15 +57,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -82,16 +80,21 @@ func main() {
 	price := decimal.NewFromFloat(5)
 	leverage := decimal.NewFromFloat(1)
 
-	order := chainClient.DerivativeOrder(defaultSubaccountID, network, &chainclient.DerivativeOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     amount,
-		Price:        price,
-		Leverage:     leverage,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		IsReduceOnly: false,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateDerivativeOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.DerivativeOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     amount,
+			Price:        price,
+			Leverage:     leverage,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			IsReduceOnly: false,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgBatchCreateDerivativeLimitOrders)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/13_MsgIncreasePositionMargin/example.go
+++ b/examples/chain/13_MsgIncreasePositionMargin/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/15_MsgWithdraw/example.go
+++ b/examples/chain/15_MsgWithdraw/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/16_MsgSubaccountTransfer/example.go
+++ b/examples/chain/16_MsgSubaccountTransfer/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/17_MsgBatchUpdateOrders/example.go
+++ b/examples/chain/17_MsgBatchUpdateOrders/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -58,15 +57,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -82,14 +80,19 @@ func main() {
 	sprice := decimal.NewFromFloat(22.5)
 	smarketIds := []string{"0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0"}
 
-	spot_order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     samount,
-		Price:        sprice,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     smarketId,
-		Cid:          uuid.NewString(),
-	})
+	spot_order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     samount,
+			Price:        sprice,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     smarketId,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	dmarketId := "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce"
 	damount := decimal.NewFromFloat(0.01)
@@ -97,16 +100,21 @@ func main() {
 	dleverage := decimal.RequireFromString("2")
 	dmarketIds := []string{"0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce"}
 
-	derivative_order := chainClient.DerivativeOrder(defaultSubaccountID, network, &chainclient.DerivativeOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     damount,
-		Price:        dprice,
-		Leverage:     dleverage,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     dmarketId,
-		IsReduceOnly: false,
-		Cid:          uuid.NewString(),
-	})
+	derivative_order := chainClient.CreateDerivativeOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.DerivativeOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     damount,
+			Price:        dprice,
+			Leverage:     dleverage,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     dmarketId,
+			IsReduceOnly: false,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgBatchUpdateOrders)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/18_MsgBid/example.go
+++ b/examples/chain/18_MsgBid/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/19_MsgGrant/example.go
+++ b/examples/chain/19_MsgGrant/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -48,21 +45,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/1_MsgSend/example.go
+++ b/examples/chain/1_MsgSend/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 	}
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/20_MsgExec/example.go
+++ b/examples/chain/20_MsgExec/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
@@ -73,17 +72,16 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
 	txFactory := chainclient.NewTxFactory(clientCtx)
 	txFactory = txFactory.WithGasPrices(client.DefaultGasPriceWithDenom)
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionTxFactory(&txFactory),
 	)
 
@@ -101,13 +99,18 @@ func main() {
 
 	amount := decimal.NewFromFloat(2)
 	price := decimal.NewFromFloat(22.55)
-	order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY,
-		Quantity:     amount,
-		Price:        price,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-	})
+	order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY,
+			Quantity:     amount,
+			Price:        price,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+		},
+		marketsAssistant,
+	)
 
 	// manually pack msg into Any type
 	msg0 := exchangetypes.MsgCreateSpotLimitOrder{

--- a/examples/chain/21_MsgRevoke/example.go
+++ b/examples/chain/21_MsgRevoke/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/22_MsgSendToEth/example.go
+++ b/examples/chain/22_MsgSendToEth/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/23_MsgRelayPriceFeedPrice/example.go
+++ b/examples/chain/23_MsgRelayPriceFeedPrice/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/24_MsgRegisterAsDMM/example.go
+++ b/examples/chain/24_MsgRegisterAsDMM/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/25_MsgDelegate/example.go
+++ b/examples/chain/25_MsgDelegate/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/26_MsgWithdrawDelegatorReward/example.go
+++ b/examples/chain/26_MsgWithdrawDelegatorReward/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/27_QueryAuthzGrants/example.go
+++ b/examples/chain/27_QueryAuthzGrants/example.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-
 	"github.com/InjectiveLabs/sdk-go/client"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -81,6 +66,8 @@ func main() {
 		Grantee:    grantee,
 		MsgTypeUrl: msg_type_url,
 	}
+
+	ctx := context.Background()
 
 	res, err := chainClient.GetAuthzGrants(ctx, req)
 	if err != nil {

--- a/examples/chain/28_BankBalances/example.go
+++ b/examples/chain/28_BankBalances/example.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
@@ -48,21 +45,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -71,6 +56,7 @@ func main() {
 	}
 
 	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankBalances(ctx, address)
 	if err != nil {

--- a/examples/chain/29_BankBalance/example.go
+++ b/examples/chain/29_BankBalance/example.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-
 	"github.com/InjectiveLabs/sdk-go/client"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -73,6 +58,7 @@ func main() {
 
 	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
 	denom := "inj"
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankBalance(ctx, address, denom)
 	if err != nil {

--- a/examples/chain/2_MsgDeposit/example.go
+++ b/examples/chain/2_MsgDeposit/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 	}
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/30_MsgExternalTransfer/example.go
+++ b/examples/chain/30_MsgExternalTransfer/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/31_MsgMultiSend/example.go
+++ b/examples/chain/31_MsgMultiSend/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -52,21 +49,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/34_OfflineSigning/example.go
+++ b/examples/chain/34_OfflineSigning/example.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"io/ioutil"
 	"os"
@@ -70,15 +69,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -91,13 +89,18 @@ func main() {
 	amount := decimal.NewFromFloat(2)
 	price := decimal.NewFromFloat(1.02)
 
-	order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     amount,
-		Price:        price,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-	})
+	order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     amount,
+			Price:        price,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgCreateSpotLimitOrder)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/35_StreamEventOrderFail/example.go
+++ b/examples/chain/35_StreamEventOrderFail/example.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-
 	"github.com/InjectiveLabs/sdk-go/client"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -24,21 +20,9 @@ func main() {
 		panic(err)
 	}
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/36_StreamEventOrderbookUpdate/example.go
+++ b/examples/chain/36_StreamEventOrderbookUpdate/example.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
-
 	"github.com/InjectiveLabs/sdk-go/client"
 
 	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
@@ -25,21 +21,9 @@ func main() {
 		panic(err)
 	}
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/38_MsgLiquidate/example.go
+++ b/examples/chain/38_MsgLiquidate/example.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -54,21 +51,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmRPC)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/39_GetTx/example.go
+++ b/examples/chain/39_GetTx/example.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -51,27 +49,17 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmRPC)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
 	if err != nil {
 		panic(err)
 	}
+
+	ctx := context.Background()
 
 	timeOutCtx, cancelFn := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelFn()

--- a/examples/chain/3_MsgCreateSpotLimitOrder/example.go
+++ b/examples/chain/3_MsgCreateSpotLimitOrder/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -56,15 +55,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -79,14 +77,19 @@ func main() {
 	amount := decimal.NewFromFloat(2)
 	price := decimal.NewFromFloat(22.55)
 
-	order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     amount,
-		Price:        price,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     amount,
+			Price:        price,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgCreateSpotLimitOrder)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/40_ChainStream/example.go
+++ b/examples/chain/40_ChainStream/example.go
@@ -8,8 +8,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 )
 
 func main() {
@@ -25,21 +23,9 @@ func main() {
 	}
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -89,6 +75,9 @@ func main() {
 			Symbol: []string{"INJ", "USDT"},
 		},
 	}
+
+	ctx := context.Background()
+
 	stream, err := chainClient.ChainStream(ctx, req)
 	if err != nil {
 		panic(err)

--- a/examples/chain/42_BankSpendableBalances/example.go
+++ b/examples/chain/42_BankSpendableBalances/example.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -49,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -73,6 +59,7 @@ func main() {
 
 	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankSpendableBalances(ctx, address, &pagination)
 	if err != nil {

--- a/examples/chain/42_BankSpendableBalances/example.go
+++ b/examples/chain/42_BankSpendableBalances/example.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetBankSpendableBalances(ctx, address, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/43_BankSpendableBalancesByDenom/example.go
+++ b/examples/chain/43_BankSpendableBalancesByDenom/example.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
+	denom := "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"
+
+	res, err := chainClient.GetBankSpendableBalancesByDenom(ctx, address, denom)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/43_BankSpendableBalancesByDenom/example.go
+++ b/examples/chain/43_BankSpendableBalancesByDenom/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
 	"os"
@@ -47,21 +45,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -71,6 +57,7 @@ func main() {
 
 	address := "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
 	denom := "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankSpendableBalancesByDenom(ctx, address, denom)
 	if err != nil {

--- a/examples/chain/44_BankTotalSupply/example.go
+++ b/examples/chain/44_BankTotalSupply/example.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -49,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -72,6 +58,7 @@ func main() {
 	}
 
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankTotalSupply(ctx, &pagination)
 	if err != nil {

--- a/examples/chain/44_BankTotalSupply/example.go
+++ b/examples/chain/44_BankTotalSupply/example.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetBankTotalSupply(ctx, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/45_BankSupplyOf/example.go
+++ b/examples/chain/45_BankSupplyOf/example.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	denom := "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"
+
+	res, err := chainClient.GetBankSupplyOf(ctx, denom)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/45_BankSupplyOf/example.go
+++ b/examples/chain/45_BankSupplyOf/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
 	"os"
@@ -47,21 +45,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -70,6 +56,7 @@ func main() {
 	}
 
 	denom := "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankSupplyOf(ctx, denom)
 	if err != nil {

--- a/examples/chain/46_DenomMetadata/example.go
+++ b/examples/chain/46_DenomMetadata/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
 	"os"
@@ -47,21 +45,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -70,6 +56,7 @@ func main() {
 	}
 
 	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
+	ctx := context.Background()
 
 	res, err := chainClient.GetDenomMetadata(ctx, denom)
 	if err != nil {

--- a/examples/chain/46_DenomMetadata/example.go
+++ b/examples/chain/46_DenomMetadata/example.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
+
+	res, err := chainClient.GetDenomMetadata(ctx, denom)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/47_DenomsMetadata/example.go
+++ b/examples/chain/47_DenomsMetadata/example.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetDenomsMetadata(ctx, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/47_DenomsMetadata/example.go
+++ b/examples/chain/47_DenomsMetadata/example.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -49,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -72,6 +58,7 @@ func main() {
 	}
 
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetDenomsMetadata(ctx, &pagination)
 	if err != nil {

--- a/examples/chain/48_DenomOwners/example.go
+++ b/examples/chain/48_DenomOwners/example.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetDenomOwners(ctx, denom, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/48_DenomOwners/example.go
+++ b/examples/chain/48_DenomOwners/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -48,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -72,6 +58,7 @@ func main() {
 
 	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetDenomOwners(ctx, denom, &pagination)
 	if err != nil {

--- a/examples/chain/49_DenomOwners/example.go
+++ b/examples/chain/49_DenomOwners/example.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetDenomOwners(ctx, denom, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/49_DenomOwners/example.go
+++ b/examples/chain/49_DenomOwners/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -48,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -72,6 +58,7 @@ func main() {
 
 	denom := "factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetDenomOwners(ctx, denom, &pagination)
 	if err != nil {

--- a/examples/chain/4_MsgCreateSpotMarketOrder/example.go
+++ b/examples/chain/4_MsgCreateSpotMarketOrder/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -57,15 +56,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -79,14 +77,19 @@ func main() {
 	amount := decimal.NewFromFloat(0.1)
 	price := decimal.NewFromFloat(22)
 
-	order := chainClient.SpotOrder(defaultSubaccountID, network, &chainclient.SpotOrderData{
-		OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
-		Quantity:     amount,
-		Price:        price,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateSpotOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.SpotOrderData{
+			OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
+			Quantity:     amount,
+			Price:        price,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgCreateSpotMarketOrder)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/50_BankSendEnabled/example.go
+++ b/examples/chain/50_BankSendEnabled/example.go
@@ -7,8 +7,6 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -48,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -72,6 +58,7 @@ func main() {
 
 	denoms := []string{"factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"}
 	pagination := query.PageRequest{Limit: 10}
+	ctx := context.Background()
 
 	res, err := chainClient.GetBankSendEnabled(ctx, denoms, &pagination)
 	if err != nil {

--- a/examples/chain/50_BankSendEnabled/example.go
+++ b/examples/chain/50_BankSendEnabled/example.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	"github.com/InjectiveLabs/sdk-go/client/core"
+	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"os"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint, "/websocket")
+	if err != nil {
+		panic(err)
+	}
+
+	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		senderAddress.String(),
+		cosmosKeyring,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	exchangeClient, err := exchangeclient.NewExchangeClient(network)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	if err != nil {
+		panic(err)
+	}
+
+	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+		clientCtx,
+		network,
+		marketsAssistant,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	denoms := []string{"factory/inj107aqkjc3t5r3l9j4n9lgrma5tm3jav8qgppz6m/position"}
+	pagination := query.PageRequest{Limit: 10}
+
+	res, err := chainClient.GetBankSendEnabled(ctx, denoms, &pagination)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+
+}

--- a/examples/chain/5_MsgCancelSpotOrder/example.go
+++ b/examples/chain/5_MsgCancelSpotOrder/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/6_MsgCreateDerivativeLimitOrder/example.go
+++ b/examples/chain/6_MsgCreateDerivativeLimitOrder/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -57,15 +56,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -80,16 +78,21 @@ func main() {
 	price := decimal.RequireFromString("31000") //31,000
 	leverage := decimal.RequireFromString("2.5")
 
-	order := chainClient.DerivativeOrder(defaultSubaccountID, network, &chainclient.DerivativeOrderData{
-		OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
-		Quantity:     amount,
-		Price:        price,
-		Leverage:     leverage,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		IsReduceOnly: true,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateDerivativeOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.DerivativeOrderData{
+			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
+			Quantity:     amount,
+			Price:        price,
+			Leverage:     leverage,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			IsReduceOnly: true,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgCreateDerivativeLimitOrder)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/7_MsgCreateDerivativeMarketOrder/example.go
+++ b/examples/chain/7_MsgCreateDerivativeMarketOrder/example.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/InjectiveLabs/sdk-go/client/core"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"github.com/google/uuid"
 	"os"
@@ -58,15 +57,14 @@ func main() {
 	}
 
 	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
 	if err != nil {
 		panic(err)
 	}
 
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 
@@ -81,16 +79,21 @@ func main() {
 	price := decimal.RequireFromString("33000") //33,000
 	leverage := decimal.RequireFromString("2.5")
 
-	order := chainClient.DerivativeOrder(defaultSubaccountID, network, &chainclient.DerivativeOrderData{
-		OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
-		Quantity:     amount,
-		Price:        price,
-		Leverage:     leverage,
-		FeeRecipient: senderAddress.String(),
-		MarketId:     marketId,
-		IsReduceOnly: true,
-		Cid:          uuid.NewString(),
-	})
+	order := chainClient.CreateDerivativeOrder(
+		defaultSubaccountID,
+		network,
+		&chainclient.DerivativeOrderData{
+			OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
+			Quantity:     amount,
+			Price:        price,
+			Leverage:     leverage,
+			FeeRecipient: senderAddress.String(),
+			MarketId:     marketId,
+			IsReduceOnly: true,
+			Cid:          uuid.NewString(),
+		},
+		marketsAssistant,
+	)
 
 	msg := new(exchangetypes.MsgCreateDerivativeMarketOrder)
 	msg.Sender = senderAddress.String()

--- a/examples/chain/8_MsgCancelDerivativeOrder/example.go
+++ b/examples/chain/8_MsgCancelDerivativeOrder/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -49,21 +46,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 

--- a/examples/chain/9_MsgBatchCancelSpotOrders/example.go
+++ b/examples/chain/9_MsgBatchCancelSpotOrders/example.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/InjectiveLabs/sdk-go/client"
-	"github.com/InjectiveLabs/sdk-go/client/core"
-	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 	"os"
 	"time"
 
@@ -50,21 +47,9 @@ func main() {
 
 	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
 
-	exchangeClient, err := exchangeclient.NewExchangeClient(network)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx := context.Background()
-	marketsAssistant, err := core.NewMarketsAssistantUsingExchangeClient(ctx, exchangeClient)
-	if err != nil {
-		panic(err)
-	}
-
-	chainClient, err := chainclient.NewChainClientWithMarketsAssistant(
+	chainClient, err := chainclient.NewChainClient(
 		clientCtx,
 		network,
-		marketsAssistant,
 		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
 	)
 


### PR DESCRIPTION
- Added all missing bank module endpoints support in ChainClient.
- Included logic in the MarketsAssistant to be able to use all tokens from the chain denoms metadata (and not only the tokens that are part of an active market)
- Discovered an inconsistency in the way the MarketsAssistant was added as an instance variable in the ChainClient in the last PR. The new functionality for tokens requires the use of a ChainClient instance to instantiate the MarketsAssistant. The assistant was removed from the ChainClient and was added as a parameter to the two functions that require it: `SpotOrder` and `DerivativeOrder`. To make the change backwards compatible the functions `SpotOrder` and `DerivativeOrder` were marked as deprecated, and two new functions were created adding also the MarketsAssistant parameter.