### PR TITLE
(fix) Updated examples for oracle price requests

### DIFF
--- a/examples/exchange/oracle/1_StreamPrices/example.go
+++ b/examples/exchange/oracle/1_StreamPrices/example.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 
 	"github.com/InjectiveLabs/sdk-go/client/common"

--- a/examples/exchange/oracle/1_StreamPrices/example.go
+++ b/examples/exchange/oracle/1_StreamPrices/example.go
@@ -4,22 +4,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 )
 
 func main() {
-	network := common.LoadNetwork("mainnet", "lb")
+	network := common.LoadNetwork("testnet", "lb")
 	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
-	baseSymbol := "BTC"
-	quoteSymbol := "USDT"
-	oracleType := "bandibc"
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
+	market := marketsAssistant.AllDerivativeMarkets()["0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"]
+
+	baseSymbol := market.OracleBase
+	quoteSymbol := market.OracleQuote
+	oracleType := market.OracleType
 	stream, err := exchangeClient.StreamPrices(ctx, baseSymbol, quoteSymbol, oracleType)
 	if err != nil {
 		panic(err)

--- a/examples/exchange/oracle/2_Price/example.go
+++ b/examples/exchange/oracle/2_Price/example.go
@@ -4,23 +4,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	exchangeclient "github.com/InjectiveLabs/sdk-go/client/exchange"
 )
 
 func main() {
-	network := common.LoadNetwork("mainnet", "lb")
+	network := common.LoadNetwork("testnet", "lb")
 	exchangeClient, err := exchangeclient.NewExchangeClient(network)
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
-	baseSymbol := "BTC"
-	quoteSymbol := "USDT"
-	oracleType := "BandIBC"
-	oracleScaleFactor := uint32(6)
+	marketsAssistant, err := chainclient.NewMarketsAssistantInitializedFromChain(ctx, exchangeClient)
+	market := marketsAssistant.AllDerivativeMarkets()["0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"]
+
+	baseSymbol := market.OracleBase
+	quoteSymbol := market.OracleQuote
+	oracleType := market.OracleType
+	oracleScaleFactor := uint32(0)
 	res, err := exchangeClient.GetPrice(ctx, baseSymbol, quoteSymbol, oracleType, oracleScaleFactor)
 	if err != nil {
 		fmt.Println(err)

--- a/examples/exchange/oracle/2_Price/example.go
+++ b/examples/exchange/oracle/2_Price/example.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 
 	"github.com/InjectiveLabs/sdk-go/client/common"


### PR DESCRIPTION
- Updated OracePrice examples now that Indexer only supports returning prices for "pyth" oracle type