### PR TITLE
(feat) Added a new config option to disable the auto fix of sequence …

### DIFF
--- a/client/common/network.go
+++ b/client/common/network.go
@@ -204,6 +204,22 @@ type Network struct {
 func LoadNetwork(name string, node string) Network {
 	switch name {
 
+	case "local":
+		return Network{
+			LcdEndpoint:             "http://localhost:10337",
+			TmEndpoint:              "http://localhost:26657",
+			ChainGrpcEndpoint:       "tcp://localhost:9900",
+			ChainStreamGrpcEndpoint: "tcp://localhost:9999",
+			ExchangeGrpcEndpoint:    "tcp://localhost:9910",
+			ExplorerGrpcEndpoint:    "tcp://localhost:9911",
+			ChainId:                 "injective-1",
+			FeeDenom:                "inj",
+			Name:                    "local",
+			ChainCookieAssistant:    &DisabledCookieAssistant{},
+			ExchangeCookieAssistant: &DisabledCookieAssistant{},
+			ExplorerCookieAssistant: &DisabledCookieAssistant{},
+		}
+
 	case "devnet-1":
 		return Network{
 			LcdEndpoint:             "https://devnet-1.lcd.injective.dev",

--- a/client/common/options.go
+++ b/client/common/options.go
@@ -19,15 +19,18 @@ func init() {
 }
 
 type ClientOptions struct {
-	GasPrices string
-	TLSCert   credentials.TransportCredentials
-	TxFactory *tx.Factory
+	GasPrices                 string
+	TLSCert                   credentials.TransportCredentials
+	TxFactory                 *tx.Factory
+	ShouldFixSequenceMismatch bool
 }
 
 type ClientOption func(opts *ClientOptions) error
 
 func DefaultClientOptions() *ClientOptions {
-	return &ClientOptions{}
+	return &ClientOptions{
+		ShouldFixSequenceMismatch: true,
+	}
 }
 
 func OptionGasPrices(gasPrices string) ClientOption {


### PR DESCRIPTION
This PR has been created to replace https://github.com/InjectiveLabs/sdk-go/pull/213
It implements the same changes but on top of `dev` branch

- Make the sequence mismatch error handling optional with a new configuration parameter
- Add `local` Network configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to automatically fix sequence mismatches in transactions.
	- Added support for local network configurations in the `LoadNetwork` function.

- **Enhancements**
	- Implemented a new function for building signed transactions to improve transaction handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->