### PR TITLE
fix/fix_readme_installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clone the repository locally and install needed dependencies
 ```bash
 $ git clone git@github.com:InjectiveLabs/sdk-go.git
 $ cd sdk-go
-$ go install ./...
+$ go mod download
 ```
 
 ## Run examples


### PR DESCRIPTION
- Fixed instructions on how to prepare to use the SDK after cloning the repo

Fixes https://github.com/InjectiveLabs/sdk-go/issues/222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to use `go mod download` instead of `go install ./...` for installing dependencies in the `sdk-go` repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->