### PR TITLE
fix: make PrepareFactory public so chilliass can re-use it

### DIFF
--- a/chain/exchange/types/spot_orders.go
+++ b/chain/exchange/types/spot_orders.go
@@ -143,9 +143,7 @@ func (m *SpotLimitOrder) GetUnfilledFeeAmount(fee math.LegacyDec) math.LegacyDec
 	return m.GetUnfilledNotional().Mul(fee)
 }
 
-func (m *SpotOrder) GetBalanceHoldAndMarginDenom(market *SpotMarket) (math.LegacyDec, string) {
-	var denom string
-	var balanceHold math.LegacyDec
+func (m *SpotOrder) GetBalanceHoldAndMarginDenom(market *SpotMarket) (balanceHold math.LegacyDec, denom string) {
 	if m.IsBuy() {
 		denom = market.QuoteDenom
 		if m.OrderType.IsPostOnly() {
@@ -167,9 +165,7 @@ func (m *SpotOrder) GetBalanceHoldAndMarginDenom(market *SpotMarket) (math.Legac
 	return balanceHold, denom
 }
 
-func (m *SpotLimitOrder) GetUnfilledMarginHoldAndMarginDenom(market *SpotMarket, isTransient bool) (math.LegacyDec, string) {
-	var denom string
-	var balanceHold math.LegacyDec
+func (m *SpotLimitOrder) GetUnfilledMarginHoldAndMarginDenom(market *SpotMarket, isTransient bool) (balanceHold math.LegacyDec, denom string) {
 	if m.IsBuy() {
 		var tradeFeeRate math.LegacyDec
 

--- a/chain/wasmx/types/util.go
+++ b/chain/wasmx/types/util.go
@@ -14,6 +14,7 @@ func IsAllowed(accessConfig types.AccessConfig, actor types2.AccAddress) bool {
 			}
 		}
 		return false
+	default:
+		return false
 	}
-	return false
 }

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -481,11 +481,11 @@ func (c *chainClient) syncTimeoutHeight() {
 	}
 }
 
-// prepareFactory ensures the account defined by ctx.GetFromAddress() exists and
+// PrepareFactory ensures the account defined by ctx.GetFromAddress() exists and
 // if the account number and/or the account sequence number are zero (not set),
 // they will be queried for and set on the provided Factory. A new Factory with
 // the updated fields will be returned.
-func (c *chainClient) prepareFactory(clientCtx client.Context, txf tx.Factory) (tx.Factory, error) {
+func PrepareFactory(clientCtx client.Context, txf tx.Factory) (tx.Factory, error) {
 	from := clientCtx.GetFromAddress()
 
 	if err := txf.AccountRetriever().EnsureExists(clientCtx, from); err != nil {
@@ -703,7 +703,7 @@ func (c *chainClient) GetFeeDiscountInfo(ctx context.Context, account string) (*
 func (c *chainClient) SimulateMsg(clientCtx client.Context, msgs ...sdk.Msg) (*txtypes.SimulateResponse, error) {
 	c.txFactory = c.txFactory.WithSequence(c.accSeq)
 	c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-	txf, err := c.prepareFactory(clientCtx, c.txFactory)
+	txf, err := PrepareFactory(clientCtx, c.txFactory)
 	if err != nil {
 		err = errors.Wrap(err, "failed to prepareFactory")
 		return nil, err
@@ -785,7 +785,7 @@ func (c *chainClient) buildSignedTx(clientCtx client.Context, txf tx.Factory, ms
 		c.gasWanted = adjustedGas
 	}
 
-	txf, err := c.prepareFactory(clientCtx, txf)
+	txf, err := PrepareFactory(clientCtx, txf)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepareFactory")
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced external access by making the `PrepareFactory` method in the `chainClient` struct public.
  - Modified the return order of values in the `GetBalanceHoldAndMarginDenom` and `GetUnfilledMarginHoldAndMarginDenom` functions for `SpotOrder` and `SpotLimitOrder` types.

- **Bug Fixes**
  - Added a `default` case to the `IsAllowed` function to handle unexpected inputs, improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->