### PR TITLE
chore: stork price state correct example symbol

### DIFF
--- a/proto/injective/oracle/v1beta1/oracle.proto
+++ b/proto/injective/oracle/v1beta1/oracle.proto
@@ -107,7 +107,7 @@ message CoinbasePriceState {
 message StorkPriceState {
   // timestamp of the when the price was signed by stork
   uint64 timestamp = 1;
-  // the symbol of the price, e.g. BTC
+  // the symbol of the price, e.g. BTCUSDT
   string symbol = 2;
   // the value of the price scaled by 1e18
   string value = 3 [


### PR DESCRIPTION
fix stork price state with a correct example symbol always a pair with Base and Quote (BTCUSDT) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the comment for the `symbol` field in the price state to clarify the expected format, changing from "e.g. BTC" to "e.g. BTCUSDT" to indicate a trading pair format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->