### PR TITLE
Fix: README: Clarify private key import instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ go mod download
 
 ## Run examples
 ```bash
-# import pk into keyring if you use keyring
+# import private key(pk) into keyring if you use keyring
 injectived keys unsafe-import-eth-key inj-user 5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e
 
 # run chain example


### PR DESCRIPTION
This PR updates the README file to clarify the instructions for importing a private key into the keyring.
The term “pk” has been expanded to “private key (pk)” for better understanding and clarity, especially for users who may be unfamiliar with the abbreviation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to clarify instructions for importing a private key into the keyring, enhancing user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->