### PR TITLE
Improve error messaging and enhance documentation in eip712_cosmos.go

### DIFF
--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -231,7 +231,7 @@ func traverseFields(
 
 			err = cdc.UnpackAny(any, &anyWrapper.Value)
 			if err != nil {
-				err = errors.Wrap(err, "failed to unpack Any in msg struct")
+				err = errors.Wrapf(err, "failed to unpack Any in msg struct at field %s", fieldName)
 				return err
 			}
 
@@ -354,8 +354,9 @@ func jsonNameFromTag(tag reflect.StructTag) string {
 }
 
 // _.foo_bar.baz -> TypeFooBarBaz
-// this is needed for Geth's own signing code which doesn't
-// tolerate complex type names
+// sanitizeTypedef ensures that complex type names are simplified and
+// conform to the format expected by Geth's signing code, which requires
+// PascalCase for compatibility with EIP-712.
 func sanitizeTypedef(str string) string {
 	buf := new(bytes.Buffer)
 	parts := strings.Split(str, ".")


### PR DESCRIPTION
This PR improves error handling and enhances documentation in the eip712_cosmos.go file to provide clearer messages and more detailed explanations.

##Changes:
1. Error message improvement:
- Updated the error message in traverseFields to include the field name when unpacking Any fails. This helps in identifying the specific field that caused the error.
`err = errors.Wrapf(err, "failed to unpack Any in msg struct at field %s", fieldName)`

2. Enhanced function documentation:
- Updated the comment for sanitizeTypedef to clearly explain its role in simplifying complex type names and ensuring compatibility with Geth’s signing code, which requires PascalCase for EIP-712 compliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for better context during unpacking failures.

- **Documentation**
	- Enhanced comments to clarify the purpose of the `sanitizeTypedef` function, improving understanding of type name formatting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->