### PR TITLE
Remove duplicate error handling in `authz_vote.go`

### DIFF
--- a/auth_vote/authz_vote.go
+++ b/auth_vote/authz_vote.go
@@ -22,10 +22,6 @@ func main() {
 		panic(err)
 	}
 
-	if err != nil {
-		panic(err)
-	}
-
 	senderAddress, cosmosKeyring, err := chainclient.InitCosmosKeyring(
 		os.Getenv("HOME")+"/.injectived",
 		"injectived",


### PR DESCRIPTION
This PR removes a redundant error handling block in the `authz_vote.go` file to improve code clarity and reduce unnecessary code duplication.

## hanges:
- Removed the second `if err != nil { panic(err) }` block after initializing tmClient as it was duplicated and redundant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling logic to enhance application stability and reliability.
	- Removed unnecessary error checks to allow smoother execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->