### PR TITLE
feat: add GetStatus to tmclient

### DIFF
--- a/client/tm/tmclient.go
+++ b/client/tm/tmclient.go
@@ -18,6 +18,7 @@ type TendermintClient interface {
 	GetBlockResults(ctx context.Context, height int64) (*ctypes.ResultBlockResults, error)
 	GetValidatorSet(ctx context.Context, height int64) (*ctypes.ResultValidators, error)
 	GetABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error)
+	GetStatus(ctx context.Context) (*ctypes.ResultStatus, error)
 }
 
 type tmClient struct {
@@ -88,4 +89,9 @@ func (c *tmClient) GetValidatorSet(ctx context.Context, height int64) (*ctypes.R
 // GetABCIInfo returns the node abci version
 func (c *tmClient) GetABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
 	return c.rpcClient.ABCIInfo(ctx)
+}
+
+// GetStatus returns the node status.
+func (c *tmClient) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error) {
+	return c.rpcClient.Status(ctx)
 }


### PR DESCRIPTION
This PR adds a method to `tmClient` that lets callers get the status of the Tendermint node