### PR TITLE
(fix) Fix long timeout for sync broadcast

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -845,7 +845,7 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
 			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
 		}
-		return nil, err
+		return res, err
 	}
 	if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
@@ -939,6 +939,7 @@ func (c *chainClient) broadcastTx(
 		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
 			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
 		}
+		return res, err
 	}
 	if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -849,7 +849,6 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 	} else if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
-		panic(errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code)))
 		return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
 	} else if resultTx.Height > 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
@@ -882,7 +881,6 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 			} else if resultTx.TxResult.Code != 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
-				panic(errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code)))
 				return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
 			} else if resultTx.Height > 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
@@ -945,7 +943,6 @@ func (c *chainClient) broadcastTx(
 	} else if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
-		panic(errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code)))
 		return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
 	} else if resultTx.Height > 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -836,7 +836,6 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 	if err != nil || res.TxResponse.Code != 0 {
 		return res, err
 	}
-	fixedSeq := c.accSeq
 
 	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
 	defer cancelFn()
@@ -868,10 +867,6 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 			t.Stop()
 			return nil, err
 		case <-t.C:
-			if fixedSeq != c.getAccSeq() {
-				fmt.Println(fixedSeq, c.getAccSeq())
-				return nil, errors.New("Account sequence mismatch during the broadcast")
-			}
 			resultTx, err := c.ctx.Client.Tx(awaitCtx, txHash, false)
 			if err != nil {
 				if errRes := client.CheckCometError(err, txBytes); errRes != nil {
@@ -934,7 +929,6 @@ func (c *chainClient) broadcastTx(
 	if err != nil || res.TxResponse.Code != 0 || !await {
 		return res, err
 	}
-	fixedSeq := txf.Sequence()
 
 	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
 	defer cancelFn()
@@ -966,11 +960,6 @@ func (c *chainClient) broadcastTx(
 			t.Stop()
 			return nil, err
 		case <-t.C:
-			c.syncNonce()
-			if fixedSeq != c.getAccSeq() {
-				fmt.Println(fixedSeq, c.getAccSeq())
-				return nil, errors.New("Account sequence mismatch during the broadcast")
-			}
 			resultTx, err := clientCtx.Client.Tx(awaitCtx, txHash, false)
 			if err != nil {
 				if errRes := client.CheckCometError(err, txBytes); errRes != nil {

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -846,6 +846,7 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
 			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
 		}
+		return nil, err
 	}
 	if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -836,6 +836,7 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 	if err != nil || res.TxResponse.Code != 0 {
 		return res, err
 	}
+	fixedSeq := c.accSeq
 
 	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
 	defer cancelFn()
@@ -850,6 +851,10 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 			t.Stop()
 			return nil, err
 		case <-t.C:
+			if fixedSeq != c.getAccSeq() {
+				fmt.Println(fixedSeq, c.getAccSeq())
+				return nil, errors.New("Account sequence mismatch during the broadcast")
+			}
 			resultTx, err := c.ctx.Client.Tx(awaitCtx, txHash, false)
 			if err != nil {
 				if errRes := client.CheckCometError(err, txBytes); errRes != nil {
@@ -907,11 +912,28 @@ func (c *chainClient) broadcastTx(
 	if err != nil || res.TxResponse.Code != 0 || !await {
 		return res, err
 	}
+	fixedSeq := txf.Sequence()
 
 	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
 	defer cancelFn()
 
 	txHash, _ := hex.DecodeString(res.TxResponse.TxHash)
+	resultTx, err := clientCtx.Client.Tx(awaitCtx, txHash, false)
+	if err != nil {
+		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
+			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
+		}
+	} else if resultTx.TxResult.Code != 0 {
+		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
+		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
+		panic(errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code)))
+		return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
+	} else if resultTx.Height > 0 {
+		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
+		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
+		return res, err
+	}
+
 	t := time.NewTimer(defaultBroadcastStatusPoll)
 
 	for {
@@ -921,6 +943,11 @@ func (c *chainClient) broadcastTx(
 			t.Stop()
 			return nil, err
 		case <-t.C:
+			c.syncNonce()
+			if fixedSeq != c.getAccSeq() {
+				fmt.Println(fixedSeq, c.getAccSeq())
+				return nil, errors.New("Account sequence mismatch during the broadcast")
+			}
 			resultTx, err := clientCtx.Client.Tx(awaitCtx, txHash, false)
 			if err != nil {
 				if errRes := client.CheckCometError(err, txBytes); errRes != nil {
@@ -930,6 +957,11 @@ func (c *chainClient) broadcastTx(
 				t.Reset(defaultBroadcastStatusPoll)
 				continue
 
+			} else if resultTx.TxResult.Code != 0 {
+				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
+				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
+				t.Stop()
+				return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
 			} else if resultTx.Height > 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -846,11 +846,13 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
 			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
 		}
-	} else if resultTx.TxResult.Code != 0 {
+	}
+	if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 		return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
-	} else if resultTx.Height > 0 {
+	}
+	if resultTx.Height > 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 		return res, err
@@ -878,11 +880,13 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 				t.Reset(defaultBroadcastStatusPoll)
 				continue
 
-			} else if resultTx.TxResult.Code != 0 {
+			}
+			if resultTx.TxResult.Code != 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 				return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
-			} else if resultTx.Height > 0 {
+			}
+			if resultTx.Height > 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 				return res, err
@@ -940,11 +944,13 @@ func (c *chainClient) broadcastTx(
 		if errRes := client.CheckCometError(err, txBytes); errRes != nil {
 			return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
 		}
-	} else if resultTx.TxResult.Code != 0 {
+	}
+	if resultTx.TxResult.Code != 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 		return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
-	} else if resultTx.Height > 0 {
+	}
+	if resultTx.Height > 0 {
 		resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 		res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 		return res, err
@@ -973,12 +979,14 @@ func (c *chainClient) broadcastTx(
 				t.Reset(defaultBroadcastStatusPoll)
 				continue
 
-			} else if resultTx.TxResult.Code != 0 {
+			}
+			if resultTx.TxResult.Code != 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 				t.Stop()
 				return res, errors.New(fmt.Sprintf("Failed with non-zero code %d", resultTx.TxResult.Code))
-			} else if resultTx.Height > 0 {
+			}
+			if resultTx.Height > 0 {
 				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
 				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
 				t.Stop()


### PR DESCRIPTION
Sequence number mismatch might occur during the sync broadcast causing a long active wait loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction broadcasting logic with sequence mismatch checks for improved reliability.
- **Bug Fixes**
	- Improved error handling and logging for transaction failures or mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->