### PR TITLE
fix/check_tx_result_in_sync_broadcast_before_await

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -833,7 +833,7 @@ func (c *chainClient) SyncBroadcastSignedTx(txBytes []byte) (*txtypes.BroadcastT
 	ctx := context.Background()
 
 	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.txClient.BroadcastTx, &req)
-	if err != nil {
+	if err != nil || res.TxResponse.Code != 0 {
 		return res, err
 	}
 
@@ -904,7 +904,7 @@ func (c *chainClient) broadcastTx(
 	}
 
 	res, err := common.ExecuteCall(context.Background(), c.network.ChainCookieAssistant, c.txClient.BroadcastTx, &req)
-	if !await || err != nil {
+	if err != nil || res.TxResponse.Code != 0 || !await {
 		return res, err
 	}
 


### PR DESCRIPTION
- Added validation in SyncBroadcast code to avoid waiting to see the TX in the mainpool if it has been rejected by the node during broadcast

Fixes [CHAIN-209](https://injective-labs.atlassian.net/browse/CHAIN-209)

[CHAIN-209]: https://injective-labs.atlassian.net/browse/CHAIN-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for transaction broadcasting to ensure both errors and unsuccessful transaction responses are properly managed.

- **New Features**
	- Enhanced robustness of transaction processing with updated conditions for detecting transaction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->