### PR TITLE
fix: fix slice init length

### DIFF
--- a/client/core/tokens_file_loader_test.go
+++ b/client/core/tokens_file_loader_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLoadTokensFromUrl(t *testing.T) {
-	tokensMetadata := make([]TokenMetadata, 2)
+	tokensMetadata := make([]TokenMetadata, 0, 2)
 	tokensMetadata = append(tokensMetadata, TokenMetadata{
 		Address:           "",
 		IsNative:          true,


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `2`  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the `TestLoadTokensFromUrl` function for better dynamic handling of token metadata.
	- Ensured existing tests validate the expected behavior of token loading without altering core logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->