### PR TITLE
feat/tx_broadcast_refactoring

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -83,6 +83,7 @@ type ChainClient interface {
 	SimulateMsg(clientCtx client.Context, msgs ...sdk.Msg) (*txtypes.SimulateResponse, error)
 	AsyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error)
 	SyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error)
+	BroadcastMsg(broadcastMode txtypes.BroadcastMode, msgs ...sdk.Msg) (*txtypes.BroadcastTxRequest, *txtypes.BroadcastTxResponse, error)
 
 	// Build signed tx with given accNum and accSeq, useful for offline siging
 	// If simulate is set to false, initialGas will be used
@@ -681,35 +682,6 @@ func (c *chainClient) GetAccount(ctx context.Context, address string) (*authtype
 	return res, err
 }
 
-// SyncBroadcastMsg sends Tx to chain and waits until Tx is included in block.
-func (c *chainClient) SyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
-	c.syncMux.Lock()
-	defer c.syncMux.Unlock()
-
-	sequence := c.getAccSeq()
-	c.txFactory = c.txFactory.WithSequence(sequence)
-	c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-	res, err := c.broadcastTx(c.ctx, c.txFactory, true, msgs...)
-
-	if err != nil {
-		if c.opts.ShouldFixSequenceMismatch && strings.Contains(err.Error(), "account sequence mismatch") {
-			c.syncNonce()
-			sequence := c.getAccSeq()
-			c.txFactory = c.txFactory.WithSequence(sequence)
-			c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-			log.Debugln("retrying broadcastTx with nonce", sequence)
-			res, err = c.broadcastTx(c.ctx, c.txFactory, true, msgs...)
-		}
-		if err != nil {
-			resJSON, _ := json.MarshalIndent(res, "", "\t")
-			c.logger.WithField("size", len(msgs)).WithError(err).Errorln("failed synchronously broadcast messages:", string(resJSON))
-			return nil, err
-		}
-	}
-
-	return res, nil
-}
-
 func (c *chainClient) GetFeeDiscountInfo(ctx context.Context, account string) (*exchangetypes.QueryFeeDiscountAccountInfoResponse, error) {
 	req := &exchangetypes.QueryFeeDiscountAccountInfoRequest{
 		Account: account,
@@ -744,36 +716,6 @@ func (c *chainClient) SimulateMsg(clientCtx client.Context, msgs ...sdk.Msg) (*t
 	}
 
 	return simRes, nil
-}
-
-// AsyncBroadcastMsg sends Tx to chain and doesn't wait until Tx is included in block. This method
-// cannot be used for rapid Tx sending, it is expected that you wait for transaction status with
-// external tools. If you want sdk to wait for it, use SyncBroadcastMsg.
-func (c *chainClient) AsyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
-	c.syncMux.Lock()
-	defer c.syncMux.Unlock()
-
-	sequence := c.getAccSeq()
-	c.txFactory = c.txFactory.WithSequence(sequence)
-	c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-	res, err := c.broadcastTx(c.ctx, c.txFactory, false, msgs...)
-	if err != nil {
-		if c.opts.ShouldFixSequenceMismatch && strings.Contains(err.Error(), "account sequence mismatch") {
-			c.syncNonce()
-			sequence := c.getAccSeq()
-			c.txFactory = c.txFactory.WithSequence(sequence)
-			c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-			log.Debugln("retrying broadcastTx with nonce", sequence)
-			res, err = c.broadcastTx(c.ctx, c.txFactory, false, msgs...)
-		}
-		if err != nil {
-			resJSON, _ := json.MarshalIndent(res, "", "\t")
-			c.logger.WithField("size", len(msgs)).WithError(err).Errorln("failed to asynchronously broadcast messagess:", string(resJSON))
-			return nil, err
-		}
-	}
-
-	return res, nil
 }
 
 func (c *chainClient) BuildSignedTx(clientCtx client.Context, accNum, accSeq, initialGas uint64, msgs ...sdk.Msg) ([]byte, error) {
@@ -890,57 +832,23 @@ func (c *chainClient) AsyncBroadcastSignedTx(txBytes []byte) (*txtypes.Broadcast
 func (c *chainClient) broadcastTx(
 	clientCtx client.Context,
 	txf tx.Factory,
-	await bool,
+	broadcastMode txtypes.BroadcastMode,
 	msgs ...sdk.Msg,
-) (*txtypes.BroadcastTxResponse, error) {
+) (*txtypes.BroadcastTxRequest, *txtypes.BroadcastTxResponse, error) {
 	txBytes, err := c.buildSignedTx(clientCtx, txf, msgs...)
 	if err != nil {
 		err = errors.Wrap(err, "failed to build signed Tx")
-		return nil, err
+		return nil, nil, err
 	}
 
 	req := txtypes.BroadcastTxRequest{
 		TxBytes: txBytes,
-		Mode:    txtypes.BroadcastMode_BROADCAST_MODE_SYNC,
+		Mode:    broadcastMode,
 	}
 
 	res, err := common.ExecuteCall(context.Background(), c.network.ChainCookieAssistant, c.txClient.BroadcastTx, &req)
-	if err != nil || res.TxResponse.Code != 0 || !await {
-		return res, err
-	}
+	return &req, res, err
 
-	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
-	defer cancelFn()
-
-	txHash, _ := hex.DecodeString(res.TxResponse.TxHash)
-	t := time.NewTimer(defaultBroadcastStatusPoll)
-
-	for {
-		select {
-		case <-awaitCtx.Done():
-			err := errors.Wrapf(ErrTimedOut, "%s", res.TxResponse.TxHash)
-			t.Stop()
-			return nil, err
-		case <-t.C:
-			resultTx, err := clientCtx.Client.Tx(awaitCtx, txHash, false)
-			if err != nil {
-				if errRes := client.CheckCometError(err, txBytes); errRes != nil {
-					return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
-				}
-
-				t.Reset(defaultBroadcastStatusPoll)
-				continue
-
-			} else if resultTx.Height > 0 {
-				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
-				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
-				t.Stop()
-				return res, err
-			}
-
-			t.Reset(defaultBroadcastStatusPoll)
-		}
-	}
 }
 
 // QueueBroadcastMsg enqueues a list of messages. Messages will added to the queue
@@ -970,28 +878,7 @@ func (c *chainClient) runBatchBroadcast() {
 	msgBatch := make([]sdk.Msg, 0, msgCommitBatchSizeLimit)
 
 	submitBatch := func(toSubmit []sdk.Msg) {
-		c.syncMux.Lock()
-		defer c.syncMux.Unlock()
-		sequence := c.getAccSeq()
-		c.txFactory = c.txFactory.WithSequence(sequence)
-		c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-		log.Debugln("broadcastTx with nonce", sequence)
-		res, err := c.broadcastTx(c.ctx, c.txFactory, true, toSubmit...)
-		if err != nil {
-			if c.opts.ShouldFixSequenceMismatch && strings.Contains(err.Error(), "account sequence mismatch") {
-				c.syncNonce()
-				sequence := c.getAccSeq()
-				c.txFactory = c.txFactory.WithSequence(sequence)
-				c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
-				log.Debugln("retrying broadcastTx with nonce", sequence)
-				res, err = c.broadcastTx(c.ctx, c.txFactory, true, toSubmit...)
-			}
-			if err != nil {
-				resJSON, _ := json.MarshalIndent(res, "", "\t")
-				c.logger.WithField("size", len(toSubmit)).WithError(err).Errorln("failed to broadcast messages batch:", string(resJSON))
-				return
-			}
-		}
+		res, err := c.SyncBroadcastMsg(toSubmit...)
 
 		if res.TxResponse.Code != 0 {
 			err = errors.Errorf("error %d (%s): %s", res.TxResponse.Code, res.TxResponse.Codespace, res.TxResponse.RawLog)
@@ -2650,4 +2537,83 @@ func (c *chainClient) FetchVouchersForAddress(ctx context.Context, address strin
 
 func (c *chainClient) GetNetwork() common.Network {
 	return c.network
+}
+
+// SyncBroadcastMsg sends Tx to chain and waits until Tx is included in block.
+func (c *chainClient) SyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
+	req, res, err := c.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msgs...)
+
+	if err != nil || res.TxResponse.Code != 0 {
+		return res, err
+	}
+
+	awaitCtx, cancelFn := context.WithTimeout(context.Background(), defaultBroadcastTimeout)
+	defer cancelFn()
+
+	txHash, _ := hex.DecodeString(res.TxResponse.TxHash)
+	t := time.NewTimer(defaultBroadcastStatusPoll)
+
+	for {
+		select {
+		case <-awaitCtx.Done():
+			err := errors.Wrapf(ErrTimedOut, "%s", res.TxResponse.TxHash)
+			t.Stop()
+			return nil, err
+		case <-t.C:
+			resultTx, err := c.ctx.Client.Tx(awaitCtx, txHash, false)
+			if err != nil {
+				if errRes := client.CheckCometError(err, req.TxBytes); errRes != nil {
+					return &txtypes.BroadcastTxResponse{TxResponse: errRes}, err
+				}
+
+				t.Reset(defaultBroadcastStatusPoll)
+				continue
+
+			} else if resultTx.Height > 0 {
+				resResultTx := sdk.NewResponseResultTx(resultTx, res.TxResponse.Tx, res.TxResponse.Timestamp)
+				res = &txtypes.BroadcastTxResponse{TxResponse: resResultTx}
+				t.Stop()
+				return res, err
+			}
+
+			t.Reset(defaultBroadcastStatusPoll)
+		}
+	}
+}
+
+// AsyncBroadcastMsg sends Tx to chain and doesn't wait until Tx is included in block. This method
+// cannot be used for rapid Tx sending, it is expected that you wait for transaction status with
+// external tools. If you want sdk to wait for it, use SyncBroadcastMsg.
+func (c *chainClient) AsyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastTxResponse, error) {
+	_, res, err := c.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_ASYNC, msgs...)
+	return res, err
+}
+
+// BroadcastMsg submits a group of messages in one transaction to the chain
+// The function uses the broadcast mode specified with the broadcastMode parameter
+func (c *chainClient) BroadcastMsg(broadcastMode txtypes.BroadcastMode, msgs ...sdk.Msg) (*txtypes.BroadcastTxRequest, *txtypes.BroadcastTxResponse, error) {
+	c.syncMux.Lock()
+	defer c.syncMux.Unlock()
+
+	sequence := c.getAccSeq()
+	c.txFactory = c.txFactory.WithSequence(sequence)
+	c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
+	req, res, err := c.broadcastTx(c.ctx, c.txFactory, broadcastMode, msgs...)
+	if err != nil {
+		if c.opts.ShouldFixSequenceMismatch && strings.Contains(err.Error(), "account sequence mismatch") {
+			c.syncNonce()
+			sequence := c.getAccSeq()
+			c.txFactory = c.txFactory.WithSequence(sequence)
+			c.txFactory = c.txFactory.WithAccountNumber(c.accNum)
+			log.Debugln("retrying broadcastTx with nonce", sequence)
+			req, res, err = c.broadcastTx(c.ctx, c.txFactory, broadcastMode, msgs...)
+		}
+		if err != nil {
+			resJSON, _ := json.MarshalIndent(res, "", "\t")
+			c.logger.WithField("size", len(msgs)).WithError(err).Errorln("failed to asynchronously broadcast messagess:", string(resJSON))
+			return nil, nil, err
+		}
+	}
+
+	return req, res, nil
 }

--- a/client/chain/chain_test.go
+++ b/client/chain/chain_test.go
@@ -1,6 +1,7 @@
 package chain_test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -14,6 +15,109 @@ import (
 	"github.com/InjectiveLabs/sdk-go/client/common"
 )
 
+var (
+	originalOfacListPath string
+)
+
+func setUpChainTest(t *testing.T) {
+	// Store the original OfacListPath
+	originalOfacListPath = chain.OfacListPath
+
+	// Update OfacListPath to point to the temporary directory
+	chain.OfacListPath = t.TempDir()
+
+	// Get the sender address from accountForTests
+	senderAddress, _, err := accountForTests()
+	if err != nil {
+		t.Fatalf("Failed to get sender address: %v", err)
+	}
+
+	// Create the OFAC list JSON file with the sender address
+	ofacListPath := chain.GetOfacListPath()
+	ofacList := []string{senderAddress.String()}
+
+	// Ensure the directory exists
+	if err := os.MkdirAll(chain.OfacListPath, 0755); err != nil {
+		t.Fatalf("Failed to create OFAC list directory: %v", err)
+	}
+
+	// Create the OFAC list file
+	file, err := os.Create(ofacListPath)
+	if err != nil {
+		t.Fatalf("Failed to create OFAC list file: %v", err)
+	}
+	defer file.Close()
+
+	// Encode the list as JSON
+	encoder := json.NewEncoder(file)
+	if err := encoder.Encode(ofacList); err != nil {
+		t.Fatalf("Failed to write OFAC list: %v", err)
+	}
+}
+
+func tearDownChainTest() {
+	// Restore the original OfacListPath
+	chain.OfacListPath = originalOfacListPath
+}
+
+func TestDefaultSubaccount(t *testing.T) {
+	setUpChainTest(t)
+	defer tearDownChainTest()
+
+	network := common.LoadNetwork("devnet", "lb")
+	senderAddress, cosmosKeyring, err := accountForTests()
+
+	if err != nil {
+		t.Errorf("Error creating the address %v", err)
+	}
+	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
+
+	if err != nil {
+		t.Errorf("Error creating the client %v", err)
+	}
+
+	defaultSubaccountID := chainClient.DefaultSubaccount(senderAddress)
+
+	expectedSubaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+	expectedSubaccountIdHash := eth.HexToHash(expectedSubaccountId)
+	if defaultSubaccountID != expectedSubaccountIdHash {
+		t.Error("The default subaccount is calculated incorrectly")
+	}
+}
+
+func TestGetSubaccountWithIndex(t *testing.T) {
+	setUpChainTest(t)
+	defer tearDownChainTest()
+
+	network := common.LoadNetwork("devnet", "lb")
+	senderAddress, cosmosKeyring, err := accountForTests()
+
+	if err != nil {
+		t.Errorf("Error creating the address %v", err)
+	}
+
+	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
+
+	if err != nil {
+		t.Errorf("Error creating the client %v", err)
+	}
+
+	subaccountOne := chainClient.Subaccount(senderAddress, 1)
+	subaccountThirty := chainClient.Subaccount(senderAddress, 30)
+
+	expectedSubaccounOnetId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000001"
+	expectedSubaccountOneIdHash := eth.HexToHash(expectedSubaccounOnetId)
+
+	expectedSubaccounThirtytId := "0xaf79152ac5df276d9a8e1e2e22822f971347490200000000000000000000001e"
+	expectedSubaccountThirtyIdHash := eth.HexToHash(expectedSubaccounThirtytId)
+
+	if subaccountOne != expectedSubaccountOneIdHash {
+		t.Error("The subaccount with index 1 was calculated incorrectly")
+	}
+	if subaccountThirty != expectedSubaccountThirtyIdHash {
+		t.Error("The subaccount with index 30 was calculated incorrectly")
+	}
+}
 func accountForTests() (cosmtypes.AccAddress, keyring.Keyring, error) {
 	senderAddress, cosmosKeyring, err := chain.InitCosmosKeyring(
 		os.Getenv("HOME")+"/.injectived",
@@ -51,58 +155,4 @@ func createClient(senderAddress cosmtypes.AccAddress, cosmosKeyring keyring.Keyr
 	)
 
 	return chainClient, err
-}
-
-func TestDefaultSubaccount(t *testing.T) {
-	network := common.LoadNetwork("devnet", "lb")
-	senderAddress, cosmosKeyring, err := accountForTests()
-
-	if err != nil {
-		t.Errorf("Error creating the address %v", err)
-	}
-
-	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
-
-	if err != nil {
-		t.Errorf("Error creating the client %v", err)
-	}
-
-	defaultSubaccountID := chainClient.DefaultSubaccount(senderAddress)
-
-	expectedSubaccountId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
-	expectedSubaccountIdHash := eth.HexToHash(expectedSubaccountId)
-	if defaultSubaccountID != expectedSubaccountIdHash {
-		t.Error("The default subaccount is calculated incorrectly")
-	}
-}
-
-func TestGetSubaccountWithIndex(t *testing.T) {
-	network := common.LoadNetwork("devnet", "lb")
-	senderAddress, cosmosKeyring, err := accountForTests()
-
-	if err != nil {
-		t.Errorf("Error creating the address %v", err)
-	}
-
-	chainClient, err := createClient(senderAddress, cosmosKeyring, network)
-
-	if err != nil {
-		t.Errorf("Error creating the client %v", err)
-	}
-
-	subaccountOne := chainClient.Subaccount(senderAddress, 1)
-	subaccountThirty := chainClient.Subaccount(senderAddress, 30)
-
-	expectedSubaccounOnetId := "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000001"
-	expectedSubaccountOneIdHash := eth.HexToHash(expectedSubaccounOnetId)
-
-	expectedSubaccounThirtytId := "0xaf79152ac5df276d9a8e1e2e22822f971347490200000000000000000000001e"
-	expectedSubaccountThirtyIdHash := eth.HexToHash(expectedSubaccounThirtytId)
-
-	if subaccountOne != expectedSubaccountOneIdHash {
-		t.Error("The subaccount with index 1 was calculated incorrectly")
-	}
-	if subaccountThirty != expectedSubaccountThirtyIdHash {
-		t.Error("The subaccount with index 30 was calculated incorrectly")
-	}
 }

--- a/client/chain/chain_test_support.go
+++ b/client/chain/chain_test_support.go
@@ -73,6 +73,10 @@ func (c *MockChainClient) SyncBroadcastMsg(msgs ...sdk.Msg) (*txtypes.BroadcastT
 	return &txtypes.BroadcastTxResponse{}, nil
 }
 
+func (c *MockChainClient) BroadcastMsg(broadcastMode txtypes.BroadcastMode, msgs ...sdk.Msg) (*txtypes.BroadcastTxRequest, *txtypes.BroadcastTxResponse, error) {
+	return &txtypes.BroadcastTxRequest{}, &txtypes.BroadcastTxResponse{}, nil
+}
+
 func (c *MockChainClient) BuildSignedTx(clientCtx client.Context, accNum, accSeq, initialGas uint64, msg ...sdk.Msg) ([]byte, error) {
 	return []byte(nil), nil
 }

--- a/client/chain/ofac.go
+++ b/client/chain/ofac.go
@@ -53,6 +53,7 @@ func DownloadOfacList() error {
 		return fmt.Errorf("failed to download OFAC list, status code: %d", resp.StatusCode)
 	}
 
+	fmt.Printf("Writing OFAC list to file to %s\n", OfacListPath)
 	if err := os.MkdirAll(OfacListPath, 0755); err != nil { // nolint:gocritic // 0755 is the correct permission
 		return err
 	}

--- a/examples/chain/13_BroadcastMsgWithoutSimulation/example.go
+++ b/examples/chain/13_BroadcastMsgWithoutSimulation/example.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
@@ -91,12 +93,13 @@ func main() {
 	msg.Sender = senderAddress.String()
 	msg.Order = exchangetypes.SpotOrder(*order)
 
-	result, err := clientInstance.SyncBroadcastMsg(msg)
+	_, response, err := clientInstance.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Broadcast result: %s\n", result)
+	str, _ := json.MarshalIndent(response, "", " ")
+	fmt.Print(string(str))
 
 }

--- a/examples/chain/oracle/1_MsgRelayPriceFeedPrice/example.go
+++ b/examples/chain/oracle/1_MsgRelayPriceFeedPrice/example.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 	"github.com/InjectiveLabs/sdk-go/client"
 	"github.com/InjectiveLabs/sdk-go/client/common"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 
 	oracletypes "github.com/InjectiveLabs/sdk-go/chain/oracle/types"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	// AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	result, err := chainClient.SyncBroadcastMsg(msg)
+	_, result, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/1_CreateNamespace/example.go
+++ b/examples/chain/permissions/1_CreateNamespace/example.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
@@ -82,7 +84,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/2_DeleteNamespace/example.go
+++ b/examples/chain/permissions/2_DeleteNamespace/example.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
@@ -63,7 +65,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/3_UpdateNamespace/example.go
+++ b/examples/chain/permissions/3_UpdateNamespace/example.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
@@ -67,7 +69,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/4_UpdateNamespaceRoles/example.go
+++ b/examples/chain/permissions/4_UpdateNamespaceRoles/example.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
@@ -80,7 +82,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/5_RevokeNamespaceRoles/example.go
+++ b/examples/chain/permissions/5_RevokeNamespaceRoles/example.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {
@@ -70,7 +72,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)

--- a/examples/chain/permissions/6_ClaimVoucher/example.go
+++ b/examples/chain/permissions/6_ClaimVoucher/example.go
@@ -3,14 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"os"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	"github.com/InjectiveLabs/sdk-go/client"
 	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
 	"github.com/InjectiveLabs/sdk-go/client/common"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 )
 
 func main() {

--- a/examples/chain/permissions/6_ClaimVoucher/example.go
+++ b/examples/chain/permissions/6_ClaimVoucher/example.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"os"
 
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
@@ -63,7 +64,7 @@ func main() {
 	}
 
 	//AsyncBroadcastMsg, SyncBroadcastMsg, QueueBroadcastMsg
-	response, err := chainClient.SyncBroadcastMsg(msg)
+	_, response, err := chainClient.BroadcastMsg(txtypes.BroadcastMode_BROADCAST_MODE_SYNC, msg)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Refactored the TX broadcasting logic. 
- Added a new function to allow using the Sync broadcast without passing though the SDK mechanism to ensure the TX is included in one of the next blocks

Solves [CHAIN-277](https://injective-labs.atlassian.net/browse/CHAIN-277)

[CHAIN-277]: https://injective-labs.atlassian.net/browse/CHAIN-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced transaction broadcasting with a new `BroadcastMsg` method that supports different broadcast modes.
  - Improved error handling and sequence management during message broadcasting.

- **Improvements**
  - Simplified transaction broadcasting logic across multiple example applications.
  - Added logging for OFAC list file writing process.

- **Testing**
  - Updated test infrastructure with new setup and teardown functions.
  - Added mock client support for the new broadcasting method.

- **Chores**
  - Updated import statements in example applications.
  - Reorganized code structure for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->