### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/chain/exchange/types/key.go
+++ b/chain/exchange/types/key.go
@@ -416,7 +416,7 @@ func OrdersByMarketDirectionPriceOrderHashPrefix(marketID, orderHash common.Hash
 	return append(ordersByMarketDirectionPricePrefix(marketID, price, isLong), orderHash.Bytes()...)
 }
 
-// orderIndexByMarketDirectionSubaccountPrefix allows to obtain prefix of exchange against a particular marketID, direction and price
+// ordersByMarketDirectionPricePrefix allows to obtain prefix of exchange against a particular marketID, direction and price
 func ordersByMarketDirectionPricePrefix(marketID common.Hash, price *big.Int, isLong bool) []byte {
 	return append(MarketDirectionPrefix(marketID, isLong), common.LeftPadBytes(price.Bytes(), 32)...)
 }

--- a/client/tm/tmclient.go
+++ b/client/tm/tmclient.go
@@ -41,7 +41,7 @@ func (c *tmClient) GetBlock(ctx context.Context, height int64) (*ctypes.ResultBl
 	return c.rpcClient.Block(ctx, &height)
 }
 
-// GetBlock queries for a block by height. An error is returned if the query fails.
+// GetBlockResults queries for a block by height. An error is returned if the query fails.
 func (c *tmClient) GetBlockResults(ctx context.Context, height int64) (*ctypes.ResultBlockResults, error) {
 	return c.rpcClient.BlockResults(ctx, &height)
 }

--- a/typeddata/typed_data.go
+++ b/typeddata/typed_data.go
@@ -102,7 +102,7 @@ type TypedDataDomain struct {
 
 var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Z](\w*)(\[\])?$`)
 
-// SignTextWithValidator signs the given message which can be further recovered
+// SignTextValidator signs the given message which can be further recovered
 // with the given validator.
 // hash = keccak256("\x19\x00"${address}${data}).
 func SignTextValidator(validatorData ValidatorData) (signature hexutil.Bytes, message string) {


### PR DESCRIPTION
 fix some function names in comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated comment for `ordersByMarketDirectionPricePrefix` to clarify its purpose in exchange types
	- Corrected comment for `GetBlockResults` method in tmClient
	- Renamed `SignTextWithValidator` method to `SignTextValidator` with updated documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->