### PR TITLE
Fix: EIP712Wrapper v1

### DIFF
--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -1,4 +1,4 @@
-package sdk_go
+package sdk
 
 import (
 	"bytes"

--- a/eip712_cosmos_test.go
+++ b/eip712_cosmos_test.go
@@ -1,4 +1,4 @@
-package sdk_go
+package sdk
 
 import (
 	"encoding/json"

--- a/eip712_cosmos_test.go
+++ b/eip712_cosmos_test.go
@@ -1,0 +1,344 @@
+package sdk_go
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
+	cosmtypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/typeddata"
+)
+
+func TestEIP712Wrapper(t *testing.T) {
+	require := require.New(t)
+
+	// Setup test codec
+	chainCtx, _ := chainclient.NewClientContext("", "", nil)
+	protoCodec := codec.NewProtoCodec(chainCtx.InterfaceRegistry)
+
+	// Test fixture
+
+	var testReq prepareEip712Payload
+	err := json.Unmarshal([]byte(testEIP712WrapperJSON), &testReq)
+	require.NoError(err)
+
+	legacytx.RegressionTestingAminoCodec = codec.NewLegacyAmino()
+
+	msgs, err := unmarshalTestMsgs(protoCodec, testReq.Msgs)
+	require.NoError(err)
+
+	feePriceAmount, ok := math.NewIntFromString(testReq.Fee.Price[0].Amount)
+	if !ok {
+		require.True(ok, fmt.Sprintf("wrong fee price amount: %s", testReq.Fee.Price[0].Amount))
+	}
+
+	// Create wrapper function
+	wrapper := func(
+		cdc *codec.ProtoCodec,
+		chainID uint64,
+		signerData *authsigning.SignerData,
+		timeoutHeight uint64,
+		memo string,
+		feeInfo legacytx.StdFee,
+		msgs []cosmtypes.Msg,
+		feeDelegation *FeeDelegationOptions,
+	) (typeddata.TypedData, error) {
+		return WrapTxToEIP712(cdc, chainID, signerData, timeoutHeight, memo, feeInfo, msgs, feeDelegation)
+	}
+
+	// Test wrapper execution
+	typedData, err := wrapper(
+		protoCodec,
+		uint64(testReq.ChainID),
+		&authsigning.SignerData{
+			ChainID:       "injective-777",
+			AccountNumber: 3,
+			Sequence:      0,
+		},
+		uint64(testReq.TimeoutHeight),
+		testReq.Memo,
+		legacytx.StdFee{
+			Gas: uint64(testReq.Fee.Gas),
+			Amount: []cosmtypes.Coin{
+				{
+					Denom:  testReq.Fee.Price[0].Denom,
+					Amount: feePriceAmount,
+				},
+			},
+		},
+		msgs,
+		&FeeDelegationOptions{},
+	)
+	require.NoError(err)
+
+	require.NotNil(typedData)
+	require.Equal("Injective Web3", typedData.Domain.Name)
+	require.Equal("1.0.0", typedData.Domain.Version)
+	require.Equal("cosmos", typedData.Domain.VerifyingContract)
+	require.Equal("0", typedData.Domain.Salt)
+	require.Equal("Tx", typedData.PrimaryType)
+
+	typedDataRaw, err := json.MarshalIndent(typedData, "", "\t")
+	require.NoError(err)
+	require.Equal(testEIP712WrapperOutJSON, string(typedDataRaw))
+}
+
+func unmarshalTestMsgs(cdc codec.ProtoCodecMarshaler, msgsBytes []json.RawMessage) (msgs []cosmtypes.Msg, err error) {
+	for _, protoMsg := range msgsBytes {
+		var msg cosmtypes.Msg
+		if err := cdc.UnmarshalInterfaceJSON(protoMsg, &msg); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal msg")
+		}
+
+		msgs = append(msgs, msg)
+	}
+
+	return msgs, nil
+}
+
+var testEIP712WrapperJSON = `{
+    "chainId": "11155111",
+    "signerAddress": "0xaf79152ac5df276d9a8e1e2e22822f9713474902",
+    "sequence": "0",
+    "accountNumber": "3",
+    "memo": "",
+    "timeoutHeight": "999999999",
+    "fee": {
+        "price": [
+            {
+                "denom": "inj",
+                "amount": "160000000"
+            }
+        ],
+        "gas": "400000",
+        "delegateFee": false
+    },
+    "msgs": [
+        {
+            "@type": "/injective.exchange.v1beta1.MsgCancelSpotOrder",
+            "sender": "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku",
+            "market_id": "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0",
+            "subaccount_id": "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000",
+            "order_hash": "0x3b1bcc8ab01e1e0f1f2cf9de5f44267bed6368fabd62adbcf3826a207340194e",
+            "cid": "order-123"
+        }
+    ],
+    "eip712Wrapper": "v1"
+}`
+
+var testEIP712WrapperOutJSON = `{
+	"types": {
+		"Coin": [
+			{
+				"name": "denom",
+				"type": "string"
+			},
+			{
+				"name": "amount",
+				"type": "string"
+			}
+		],
+		"EIP712Domain": [
+			{
+				"name": "name",
+				"type": "string"
+			},
+			{
+				"name": "version",
+				"type": "string"
+			},
+			{
+				"name": "chainId",
+				"type": "uint256"
+			},
+			{
+				"name": "verifyingContract",
+				"type": "string"
+			},
+			{
+				"name": "salt",
+				"type": "string"
+			}
+		],
+		"Fee": [
+			{
+				"name": "amount",
+				"type": "Coin[]"
+			},
+			{
+				"name": "gas",
+				"type": "string"
+			}
+		],
+		"Msg": [
+			{
+				"name": "type",
+				"type": "string"
+			},
+			{
+				"name": "value",
+				"type": "MsgValue"
+			}
+		],
+		"MsgValue": [
+			{
+				"name": "sender",
+				"type": "string"
+			},
+			{
+				"name": "market_id",
+				"type": "string"
+			},
+			{
+				"name": "subaccount_id",
+				"type": "string"
+			},
+			{
+				"name": "order_hash",
+				"type": "string"
+			},
+			{
+				"name": "cid",
+				"type": "string"
+			}
+		],
+		"Tx": [
+			{
+				"name": "account_number",
+				"type": "string"
+			},
+			{
+				"name": "chain_id",
+				"type": "string"
+			},
+			{
+				"name": "fee",
+				"type": "Fee"
+			},
+			{
+				"name": "memo",
+				"type": "string"
+			},
+			{
+				"name": "msgs",
+				"type": "Msg[]"
+			},
+			{
+				"name": "sequence",
+				"type": "string"
+			},
+			{
+				"name": "timeout_height",
+				"type": "string"
+			}
+		]
+	},
+	"primaryType": "Tx",
+	"domain": {
+		"name": "Injective Web3",
+		"version": "1.0.0",
+		"chainId": "0xaa36a7",
+		"verifyingContract": "cosmos",
+		"salt": "0"
+	},
+	"message": {
+		"account_number": "3",
+		"chain_id": "injective-777",
+		"fee": {
+			"amount": [
+				{
+					"amount": "160000000",
+					"denom": "inj"
+				}
+			],
+			"gas": "400000"
+		},
+		"memo": "",
+		"msgs": [
+			{
+				"type": "exchange/MsgCancelSpotOrder",
+				"value": {
+					"cid": "order-123",
+					"market_id": "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0",
+					"order_hash": "0x3b1bcc8ab01e1e0f1f2cf9de5f44267bed6368fabd62adbcf3826a207340194e",
+					"sender": "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku",
+					"subaccount_id": "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
+				}
+			}
+		],
+		"sequence": "0",
+		"timeout_height": "999999999"
+	}
+}`
+
+type prepareEip712Payload struct {
+	// Specify chainID for the target tx
+	ChainID uint64AsString `json:"chainId"`
+	// Specify Ethereum address of a signer
+	SignerAddress string `json:"signerAddress"`
+	// Sequence number of the transaction signer
+	Sequence uint64AsString `json:"sequence"`
+	// Account number of the transaction signer
+	AccountNumber uint64AsString `json:"accountNumber"`
+	// Textual memo information to attach with tx
+	Memo string `json:"memo"`
+	// Block height until which the transaction is valid.
+	TimeoutHeight uint64AsString `json:"timeoutHeight"`
+	// Transaction fee details.
+	Fee *cosmosTxFee `json:"fee"`
+	// List of Cosmos proto3-encoded Msgs to include in a single tx
+	Msgs []json.RawMessage `json:"msgs"`
+	// The wrapper of the EIP712 message, 'v1'/'v2' or 'V1'/'V2'
+	Eip712Wrapper string `json:"eip712Wrapper"`
+}
+
+type cosmosTxFee struct {
+	// Transaction gas price
+	Price []*cosmosCoin `json:"price"`
+	// Transaction gas limit
+	Gas uint64AsString `json:"gas"`
+	// Explicitly require fee delegation when set to true. Or don't care = false.
+	// Will be replaced by other flag in the next version.
+	DelegateFee bool `json:"delegateFee"`
+}
+
+type cosmosCoin struct {
+	// Coin denominator
+	Denom string `json:"denom"`
+	// Coin amount (big int)
+	Amount string `json:"amount"`
+}
+
+type uint64AsString uint64
+
+// MarshalJSON encodes uint64AsString as a string.
+func (u uint64AsString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatUint(uint64(u), 10))
+}
+
+// UnmarshalJSON decodes a JSON string into uint64AsString.
+func (u *uint64AsString) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*u = uint64AsString(v)
+	return nil
+}
+
+type feeDelegationOptions struct {
+	FeePayer cosmtypes.AccAddress
+}

--- a/typeddata/typed_data.go
+++ b/typeddata/typed_data.go
@@ -2,13 +2,16 @@ package typeddata
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -18,6 +21,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cosmtypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 )
 
 type SigFormat struct {
@@ -105,27 +114,25 @@ var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Z](\w*)(\[\])?$`)
 // SignTextWithValidator signs the given message which can be further recovered
 // with the given validator.
 // hash = keccak256("\x19\x00"${address}${data}).
-func SignTextValidator(validatorData ValidatorData) (signature hexutil.Bytes, message string) {
+func SignTextValidator(validatorData ValidatorData) (hexutil.Bytes, string) {
 	msg := fmt.Sprintf("\x19\x00%s%s", string(validatorData.Address.Bytes()), string(validatorData.Message))
 	return crypto.Keccak256([]byte(msg)), msg
 }
 
-// ComputeTypedDataHash computes keccak hash of typed data for signing.
-func ComputeTypedDataHash(typedData TypedData) ([]byte, error) {
+// ComputeTypedDataAndHash computes the typed data and its keccak hash for signing
+func ComputeTypedDataAndHash(typedData TypedData) (hash, data []byte, err error) {
 	domainSeparator, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
 	if err != nil {
-		err = errors.Wrap(err, "failed to pack and hash typedData EIP712Domain")
-		return nil, err
+		return nil, nil, errors.Wrap(err, "failed to pack and hash typedData EIP712Domain")
 	}
 
 	typedDataHash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
 	if err != nil {
-		err = errors.Wrap(err, "failed to pack and hash typedData primary type")
-		return nil, err
+		return nil, nil, errors.Wrap(err, "failed to pack and hash typedData primary type")
 	}
 
 	rawData := []byte(fmt.Sprintf("\x19\x01%s%s", string(domainSeparator), string(typedDataHash)))
-	return crypto.Keccak256(rawData), nil
+	return crypto.Keccak256(rawData), rawData, nil
 }
 
 // HashStruct generates a keccak256 hash of the encoding of the provided data
@@ -227,6 +234,7 @@ func (typedData *TypedData) EncodeData(primaryType string, data map[string]inter
 	for _, field := range typedData.Types[primaryType] {
 		encType := field.Type
 		encValue := data[field.Name]
+
 		switch {
 		case encType[len(encType)-1:] == "]":
 			arrayValue, ok := encValue.([]interface{})
@@ -800,4 +808,508 @@ func (domain *TypedDataDomain) Map() map[string]interface{} {
 		dataMap["salt"] = domain.Salt
 	}
 	return dataMap
+}
+
+var (
+	LegacyAminoCodec *codec.LegacyAmino
+	ProtoCodec       *codec.ProtoCodec
+)
+
+func SetCodec(amino *codec.LegacyAmino, proto *codec.ProtoCodec) {
+	LegacyAminoCodec, ProtoCodec = amino, proto
+}
+
+func GetEIP712TypedDataForMsg(signDocBytes []byte) (TypedData, error) {
+	txData := make(map[string]interface{})
+	if err := json.Unmarshal(signDocBytes, &txData); err != nil {
+		return TypedData{}, errors.Wrap(err, "failed to unmarshal signDocBytes")
+	}
+
+	// parse txData to StdSignDoc in order to parse the msg for ExtractMsgTypes
+	var signDoc legacytx.StdSignDoc
+	if err := LegacyAminoCodec.UnmarshalJSON(signDocBytes, &signDoc); err != nil {
+		return TypedData{}, err
+	}
+
+	var msg cosmtypes.Msg
+	if err := LegacyAminoCodec.UnmarshalJSON(signDoc.Msgs[0], &msg); err != nil {
+		return TypedData{}, errors.Wrap(err, "failed to unmarshal msg")
+	}
+
+	// For some reason this type cast does not work during UnmarshalJSON above
+	// If the underlying msg does implement the UnpackInterfacesMessage interface (MsgGrant, MsgExec...),
+	// we explicitly call the method here to ensure potential Any fields within the message are correctly parsed
+	if unpacker, ok := msg.(codectypes.UnpackInterfacesMessage); ok {
+		if err := unpacker.UnpackInterfaces(codectypes.AminoJSONUnpacker{Cdc: LegacyAminoCodec.Amino}); err != nil {
+			return TypedData{}, errors.Wrap(err, "failed to unpack msg")
+		}
+	}
+
+	msgTypes, err := ExtractMsgTypes(ProtoCodec, "MsgValue", msg)
+	if err != nil {
+		return TypedData{}, errors.Wrap(err, "failed to extract msg types")
+	}
+
+	if txData["fee"] != nil {
+		msgTypes["Fee"] = []Type{
+			{Name: "amount", Type: "Coin[]"},
+			{Name: "gas", Type: "string"},
+		}
+	}
+
+	// set timeout_height to 0 in case the user forgot to provide the flag
+	if txData["timeout_height"] == nil {
+		txData["timeout_height"] = "0"
+	}
+
+	chainID, err := ParseCosmosChainID(txData["chain_id"].(string))
+	if err != nil {
+		return TypedData{}, err
+	}
+
+	// see VerifySignatureEIP712 func and its handling of chain id
+	switch chainID.Int64() {
+	case 777, 888:
+		chainID = big.NewInt(11155111) // Sepolia
+	default:
+		chainID = big.NewInt(1)
+	}
+
+	domain := TypedDataDomain{
+		Name:              "Injective Web3",
+		Version:           "1.0.0",
+		ChainId:           math.NewHexOrDecimal256(chainID.Int64()),
+		VerifyingContract: "cosmos",
+		Salt:              "0",
+	}
+
+	td := TypedData{
+		Types:       msgTypes,
+		PrimaryType: "Tx",
+		Domain:      domain,
+		Message:     txData,
+	}
+
+	return td, nil
+}
+
+func ExtractMsgTypes(cdc codec.ProtoCodecMarshaler, msgTypeName string, msg cosmtypes.Msg) (Types, error) {
+	rootTypes := Types{
+		"EIP712Domain": {
+			{
+				Name: "name",
+				Type: "string",
+			},
+			{
+				Name: "version",
+				Type: "string",
+			},
+			{
+				Name: "chainId",
+				Type: "uint256",
+			},
+			{
+				Name: "verifyingContract",
+				Type: "string",
+			},
+			{
+				Name: "salt",
+				Type: "string",
+			},
+		},
+		"Tx": {
+			{Name: "account_number", Type: "string"},
+			{Name: "chain_id", Type: "string"},
+			{Name: "fee", Type: "Fee"},
+			{Name: "memo", Type: "string"},
+			{Name: "msgs", Type: "Msg[]"},
+			{Name: "sequence", Type: "string"},
+			{Name: "timeout_height", Type: "string"},
+		},
+		"Fee": {
+			{Name: "amount", Type: "Coin[]"},
+			{Name: "gas", Type: "string"},
+		},
+		"Coin": {
+			{Name: "denom", Type: "string"},
+			{Name: "amount", Type: "string"},
+		},
+		"Msg": {
+			{Name: "type", Type: "string"},
+			{Name: "value", Type: msgTypeName},
+		},
+		msgTypeName: {},
+	}
+
+	err := walkFields(cdc, rootTypes, msgTypeName, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return rootTypes, nil
+}
+
+func walkFields(cdc codec.ProtoCodecMarshaler, typeMap Types, rootType string, in interface{}) (err error) {
+	defer doRecover(&err)
+
+	t := reflect.TypeOf(in)
+	v := reflect.ValueOf(in)
+
+	for {
+		if t.Kind() == reflect.Ptr || t.Kind() == reflect.Interface {
+			t = t.Elem()
+			v = v.Elem()
+			continue
+		}
+		break
+	}
+
+	err = traverseFields(cdc, typeMap, rootType, typeDefPrefix, t, v)
+	return
+}
+
+//nolint:gocritic // this is a handy way to return err in defered funcs
+func doRecover(err *error) {
+	if r := recover(); r != nil {
+		debug.PrintStack()
+
+		if e, ok := r.(error); ok {
+			e = errors.Wrap(e, "panicked with error")
+			*err = e
+			return
+		}
+
+		*err = errors.Errorf("%v", r)
+	}
+}
+
+const typeDefPrefix = "_"
+
+func traverseFields(
+	cdc codec.ProtoCodecMarshaler,
+	typeMap Types,
+	rootType string,
+	prefix string,
+	t reflect.Type,
+	v reflect.Value,
+) (err error) {
+	n := t.NumField()
+
+	if prefix == typeDefPrefix {
+		if len(typeMap[rootType]) == n {
+			return
+		}
+	} else {
+		typeDef := sanitizeTypedef(prefix)
+		if len(typeMap[typeDef]) == n {
+			return
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		var field reflect.Value
+		if v.IsValid() {
+			field = v.Field(i)
+		}
+
+		fieldType := t.Field(i).Type
+		fieldName := jsonNameFromTag(t.Field(i).Tag)
+		var isCollection bool
+		if fieldType.Kind() == reflect.Array || fieldType.Kind() == reflect.Slice {
+			if field.Len() == 0 {
+				// skip empty collections from type mapping
+				continue
+			}
+
+			fieldType = fieldType.Elem()
+			field = field.Index(0)
+			isCollection = true
+		}
+
+		if fieldType == cosmosAnyType {
+			any := field.Interface().(*codectypes.Any)
+			anyWrapper := &cosmosAnyWrapper{
+				Type: any.TypeUrl,
+			}
+
+			err = cdc.UnpackAny(any, &anyWrapper.Value)
+			if err != nil {
+				err = errors.Wrap(err, "failed to unpack Any in msg struct")
+				return
+			}
+
+			fieldType = reflect.TypeOf(anyWrapper)
+			field = reflect.ValueOf(anyWrapper)
+			// then continue as normal
+		}
+
+		for {
+			if fieldType.Kind() == reflect.Ptr {
+				fieldType = fieldType.Elem()
+
+				if field.IsValid() {
+					field = field.Elem()
+				}
+
+				continue
+			}
+
+			if fieldType.Kind() == reflect.Interface {
+				fieldType = reflect.TypeOf(field.Interface())
+				continue
+			}
+
+			if field.Kind() == reflect.Ptr {
+				field = field.Elem()
+				continue
+			}
+
+			break
+		}
+
+		for {
+			if fieldType.Kind() == reflect.Ptr {
+				fieldType = fieldType.Elem()
+
+				if field.IsValid() {
+					field = field.Elem()
+				}
+
+				continue
+			}
+
+			if fieldType.Kind() == reflect.Interface {
+				fieldType = reflect.TypeOf(field.Interface())
+				continue
+			}
+
+			if field.Kind() == reflect.Ptr {
+				field = field.Elem()
+				continue
+			}
+
+			break
+		}
+
+		fieldPrefix := fmt.Sprintf("%s.%s", prefix, fieldName)
+		ethTyp := typToEth(fieldType)
+		if ethTyp != "" {
+			if isCollection {
+				ethTyp += "[]"
+			}
+
+			if field.Kind() == reflect.String && field.Len() == 0 {
+				// skip empty strings from type mapping
+				continue
+			}
+
+			if prefix == typeDefPrefix {
+				typeMap[rootType] = append(typeMap[rootType], Type{
+					Name: fieldName,
+					Type: ethTyp,
+				})
+			} else {
+				typeDef := sanitizeTypedef(prefix)
+				typeMap[typeDef] = append(typeMap[typeDef], Type{
+					Name: fieldName,
+					Type: ethTyp,
+				})
+			}
+
+			continue
+		}
+
+		if fieldType.Kind() == reflect.Struct {
+			var fieldTypedef string
+			if isCollection {
+				fieldTypedef = sanitizeTypedef(fieldPrefix) + "[]"
+			} else {
+				fieldTypedef = sanitizeTypedef(fieldPrefix)
+			}
+
+			if prefix == typeDefPrefix {
+				typeMap[rootType] = append(typeMap[rootType], Type{
+					Name: fieldName,
+					Type: fieldTypedef,
+				})
+			} else {
+				typeDef := sanitizeTypedef(prefix)
+				typeMap[typeDef] = append(typeMap[typeDef], Type{
+					Name: fieldName,
+					Type: fieldTypedef,
+				})
+			}
+
+			err = traverseFields(cdc, typeMap, rootType, fieldPrefix, fieldType, field)
+			if err != nil {
+				return
+			}
+
+			continue
+		}
+	}
+
+	return nil
+}
+
+// _.foo_bar.baz -> TypeFooBarBaz
+// this is needed for Geth's own signing code which doesn't
+// tolerate complex type names
+func sanitizeTypedef(str string) string {
+	buf := new(bytes.Buffer)
+	parts := strings.Split(str, ".")
+
+	for _, part := range parts {
+		if part == "_" {
+			buf.WriteString("Type")
+			continue
+		}
+
+		subparts := strings.Split(part, "_")
+		for _, subpart := range subparts {
+			buf.WriteString(strings.Title(subpart)) //nolint // strings is used for compat
+		}
+	}
+
+	return buf.String()
+}
+
+func jsonNameFromTag(tag reflect.StructTag) string {
+	jsonTags := tag.Get("json")
+	parts := strings.Split(jsonTags, ",")
+	return parts[0]
+}
+
+var (
+	hashType      = reflect.TypeOf(common.Hash{})
+	addressType   = reflect.TypeOf(common.Address{})
+	bigIntType    = reflect.TypeOf(big.Int{})
+	cosmIntType   = reflect.TypeOf(sdkmath.Int{})
+	cosmosAnyType = reflect.TypeOf(&codectypes.Any{})
+	timeType      = reflect.TypeOf(time.Time{})
+)
+
+type cosmosAnyWrapper struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+// typToEth supports only basic types and arrays of basic types.
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md
+func typToEth(typ reflect.Type) string {
+	switch typ.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "bool"
+	case reflect.Int:
+		return "int64"
+	case reflect.Int8:
+		return "int8"
+	case reflect.Int16:
+		return "int16"
+	case reflect.Int32:
+		return "int32"
+	case reflect.Int64:
+		return "int64"
+	case reflect.Uint:
+		return "uint64"
+	case reflect.Uint8:
+		return "uint8"
+	case reflect.Uint16:
+		return "uint16"
+	case reflect.Uint32:
+		return "uint32"
+	case reflect.Uint64:
+		return "uint64"
+	case reflect.Slice:
+		ethName := typToEth(typ.Elem())
+		if ethName != "" {
+			return ethName + "[]"
+		}
+	case reflect.Array:
+		ethName := typToEth(typ.Elem())
+		if ethName != "" {
+			return ethName + "[]"
+		}
+	case reflect.Ptr:
+		if typ.Elem().ConvertibleTo(bigIntType) ||
+			typ.Elem().ConvertibleTo(timeType) ||
+			typ.Elem().ConvertibleTo(cosmIntType) {
+			return "string"
+		}
+	case reflect.Struct:
+		if typ.ConvertibleTo(hashType) ||
+			typ.ConvertibleTo(addressType) ||
+			typ.ConvertibleTo(bigIntType) ||
+			typ.ConvertibleTo(timeType) ||
+			typ.ConvertibleTo(cosmIntType) {
+			return "string"
+		}
+	}
+
+	return ""
+}
+
+func SignableTypes() Types {
+	return Types{
+		"EIP712Domain": {
+			{
+				Name: "name",
+				Type: "string",
+			},
+			{
+				Name: "version",
+				Type: "string",
+			},
+			{
+				Name: "chainId",
+				Type: "uint256",
+			},
+			{
+				Name: "verifyingContract",
+				Type: "address",
+			},
+			{
+				Name: "salt",
+				Type: "string",
+			},
+		},
+		"Tx": {
+			{Name: "context", Type: "string"},
+			{Name: "msgs", Type: "string"},
+		},
+	}
+}
+
+var (
+	ErrInvalidChainID = errors.New("invalid chain-id")
+
+	regexChainID   = `[a-z]*`
+	regexSeparator = `-{1}`
+	regexEpoch     = `[1-9][0-9]*`
+
+	cosmosChainID = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, regexChainID, regexSeparator, regexEpoch))
+)
+
+// ParseCosmosChainID parses a string chain identifier's epoch to an Ethereum-compatible
+// chain-id in *big.Int format. The function returns an error if the chain-id has an invalid format
+func ParseCosmosChainID(chainID string) (*big.Int, error) {
+	chainID = strings.TrimSpace(chainID)
+	if len(chainID) > 48 {
+		return nil, errors.Wrapf(ErrInvalidChainID, "chain-id '%s' cannot exceed 48 chars", chainID)
+	}
+
+	matches := cosmosChainID.FindStringSubmatch(chainID)
+	if matches == nil || len(matches) != 3 || matches[1] == "" {
+		return nil, errors.Wrap(ErrInvalidChainID, chainID)
+	}
+
+	// verify that the chain-id entered is a base 10 integer
+	chainIDInt, ok := new(big.Int).SetString(matches[2], 10)
+	if !ok {
+		return nil, errors.Wrapf(ErrInvalidChainID, "epoch %s must be base-10 integer format", matches[2])
+	}
+
+	return chainIDInt, nil
 }

--- a/typeddata/typed_data.go
+++ b/typeddata/typed_data.go
@@ -997,12 +997,12 @@ func traverseFields(
 
 	if prefix == typeDefPrefix {
 		if len(typeMap[rootType]) == n {
-			return
+			return nil
 		}
 	} else {
 		typeDef := sanitizeTypedef(prefix)
 		if len(typeMap[typeDef]) == n {
-			return
+			return nil
 		}
 	}
 
@@ -1035,7 +1035,7 @@ func traverseFields(
 			err = cdc.UnpackAny(any, &anyWrapper.Value)
 			if err != nil {
 				err = errors.Wrap(err, "failed to unpack Any in msg struct")
-				return
+				return err
 			}
 
 			fieldType = reflect.TypeOf(anyWrapper)
@@ -1142,7 +1142,7 @@ func traverseFields(
 
 			err = traverseFields(cdc, typeMap, rootType, fieldPrefix, fieldType, field)
 			if err != nil {
-				return
+				return errors.WithStack(err)
 			}
 
 			continue


### PR DESCRIPTION
## Problem
After some recent update injective-core switched the protobuf implementation gogoproto to protobufv2 causing JSON marshaling of messages to behave differently.  Changes that made inside injective-core were not reflected in `WrapTxToEIP712` in sdk-go.

This makes `web3gw` service of `injective-indexer` result in wrong JSON representation for `v1` requests here:
https://github.com/InjectiveLabs/injective-indexer/blob/289139bc9a5d0d270761319727bbc265b58b8138/service/web3gw/transactions_api.go#L359

## Fixes

- Implemented Amino-based packaging of `gogoproto.Message` cosmos messages.
- Added a unit-test with a fixture to ensure that the output matches the expected output.

## Test

```
$ cd sdk-go/
$ go test -run TestEIP712Wrapper .
```

Additionally, there is a playground repo to exercise parity in marshaling between Go and TypeScript:
https://github.com/InjectiveLabs/eip712v1

The outputs must match.

## Additional features

Updated  eip712 wrapper `typeddata` implementation up to date with injective-core.
Exact file copy of https://github.com/InjectiveLabs/injective-core/blob/dev-v1.14/injective-chain/app/ante/typeddata/typed_data.go

## How to use this inside Injective Indexer

Update `go.mod`:
```
github.com/InjectiveLabs/sdk-go v1.56.0-rc1.0.20250122230412-8244b7dd8955
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

🥕
