### PR TITLE
typo fix uniquify.go

### DIFF
--- a/ethereum/util/uniquify.go
+++ b/ethereum/util/uniquify.go
@@ -8,7 +8,7 @@ import (
 // Uniquify is a type of advanced mutex. It allows to create named resource locks.
 type Uniquify interface {
 	// Call executes only one callable with same id at a time.
-	// Multilpe asynchronous calls with same id will be executed sequentally.
+	// Multiple asynchronous calls with same id will be executed sequentally.
 	Call(id string, callable func() error) error
 }
 


### PR DESCRIPTION
Original: "Multilpe asynchronous calls with same id will be executed sequentally."
Corrected: "Multiple asynchronous calls with the same id will be executed sequentially."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in a comment describing asynchronous call behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->