### PR TITLE
keys.go

### DIFF
--- a/chain/oracle/bandchain/oracle/types/keys.go
+++ b/chain/oracle/bandchain/oracle/types/keys.go
@@ -42,7 +42,7 @@ var (
 	PendingResolveListStoreKey = append(GlobalStoreKeyPrefix, []byte("PendingList")...)
 	// DataSourceCountStoreKey is the key that keeps the total data source count.
 	DataSourceCountStoreKey = append(GlobalStoreKeyPrefix, []byte("DataSourceCount")...)
-	// OracleScriptCountStoreKey is the key that keeps the total oracle sciprt count.
+	// OracleScriptCountStoreKey is the key that keeps the total oracle script count.
 	OracleScriptCountStoreKey = append(GlobalStoreKeyPrefix, []byte("OracleScriptCount")...)
 
 	// RequestStoreKeyPrefix is the prefix for request store.


### PR DESCRIPTION
Before: OracleScriptCountStoreKey is the key that keeps the total oracle sciprt count.
After: OracleScriptCountStoreKey is the key that keeps the total oracle script count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typographical error in a comment related to oracle script count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->