### PR TITLE
Fix typos in `uniquify.go`, `eip712_cosmos.go`, `typed_data.go`, and `chain.go`

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -2614,7 +2614,7 @@ func (c *chainClient) BroadcastMsg(broadcastMode txtypes.BroadcastMode, msgs ...
 		}
 		if err != nil {
 			resJSON, _ := json.MarshalIndent(res, "", "\t")
-			c.logger.WithField("size", len(msgs)).WithError(err).Errorln("failed to asynchronously broadcast messagess:", string(resJSON))
+			c.logger.WithField("size", len(msgs)).WithError(err).Errorln("failed to asynchronously broadcast messages:", string(resJSON))
 			return nil, nil, err
 		}
 	}

--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -475,7 +475,7 @@ func typToEth(typ reflect.Type) string {
 	return ""
 }
 
-//nolint:gocritic // this is a handy way to return err in defered funcs
+//nolint:gocritic // this is a handy way to return err in deferred funcs
 func doRecover(err *error) {
 	if r := recover(); r != nil {
 		debug.PrintStack()

--- a/ethereum/util/uniquify.go
+++ b/ethereum/util/uniquify.go
@@ -8,7 +8,7 @@ import (
 // Uniquify is a type of advanced mutex. It allows to create named resource locks.
 type Uniquify interface {
 	// Call executes only one callable with same id at a time.
-	// Multilpe asynchronous calls with same id will be executed sequentally.
+	// Multiple asynchronous calls with same id will be executed sequentally.
 	Call(id string, callable func() error) error
 }
 

--- a/ethereum/util/uniquify.go
+++ b/ethereum/util/uniquify.go
@@ -8,7 +8,7 @@ import (
 // Uniquify is a type of advanced mutex. It allows to create named resource locks.
 type Uniquify interface {
 	// Call executes only one callable with same id at a time.
-	// Multiple asynchronous calls with same id will be executed sequentally.
+	// Multiple asynchronous calls with same id will be executed sequentially.
 	Call(id string, callable func() error) error
 }
 

--- a/typeddata/typed_data.go
+++ b/typeddata/typed_data.go
@@ -966,7 +966,7 @@ func walkFields(cdc codec.ProtoCodecMarshaler, typeMap Types, rootType string, i
 	return
 }
 
-//nolint:gocritic // this is a handy way to return err in defered funcs
+//nolint:gocritic // this is a handy way to return err in deferred funcs
 func doRecover(err *error) {
 	if r := recover(); r != nil {
 		debug.PrintStack()


### PR DESCRIPTION
1. **`chain.go`**:
   - Fixed `messagess` → `messages` in an error log.

2. **`eip712_cosmos.go` & `typed_data.go`**:
   - Corrected `defered` → `deferred` in comments.

3. **`uniquify.go`**:
   - Fixed `Multilpe` → `Multiple` and `sequentally` → `sequentially` in a function description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected log message pluralization in chain client
	- Fixed typographical errors in documentation comments

- **Improvements**
	- Enhanced EIP712 transaction data wrapping with new `WrapTxToEIP712V2` function
	- Improved error reporting and serialization approach for transaction handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->