### PR TITLE
Add Chain Queries for the Insurance Module

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -43,6 +43,7 @@ import (
 	evmtypes "github.com/InjectiveLabs/sdk-go/chain/evm/types"
 	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
 	exchangev2types "github.com/InjectiveLabs/sdk-go/chain/exchange/types/v2"
+	insurancetypes "github.com/InjectiveLabs/sdk-go/chain/insurance/types"
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	chainstreamtypes "github.com/InjectiveLabs/sdk-go/chain/stream/types"
 	chainstreamv2types "github.com/InjectiveLabs/sdk-go/chain/stream/types/v2"
@@ -468,6 +469,12 @@ type ChainClient interface {
 	FetchEVMCode(ctx context.Context, address string) (*evmtypes.QueryCodeResponse, error)
 	FetchEVMBaseFee(ctx context.Context) (*evmtypes.QueryBaseFeeResponse, error)
 
+	// Insurance module
+	FetchInsuranceFund(ctx context.Context, marketId string) (*insurancetypes.QueryInsuranceFundResponse, error)
+	FetchInsuranceFunds(ctx context.Context) (*insurancetypes.QueryInsuranceFundsResponse, error)
+	FetchPendingRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryPendingRedemptionsResponse, error)
+	FetchEstimatedRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryEstimatedRedemptionsResponse, error)
+
 	CurrentChainGasPrice() int64
 	SetGasPrice(gasPrice int64)
 
@@ -522,6 +529,7 @@ type chainClient struct {
 	txfeesQueryClient        txfeestypes.QueryClient
 	txClient                 txtypes.ServiceClient
 	wasmQueryClient          wasmtypes.QueryClient
+	insuranceQueryClient     insurancetypes.QueryClient
 	subaccountToNonce        map[ethcommon.Hash]uint32
 
 	closed  int64
@@ -628,6 +636,7 @@ func NewChainClient(
 		txfeesQueryClient:        txfeestypes.NewQueryClient(conn),
 		txClient:                 txtypes.NewServiceClient(conn),
 		wasmQueryClient:          wasmtypes.NewQueryClient(conn),
+		insuranceQueryClient:     insurancetypes.NewQueryClient(conn),
 		subaccountToNonce:        make(map[ethcommon.Hash]uint32),
 	}
 
@@ -3691,6 +3700,40 @@ func (c *chainClient) FetchEVMCode(ctx context.Context, address string) (*evmtyp
 func (c *chainClient) FetchEVMBaseFee(ctx context.Context) (*evmtypes.QueryBaseFeeResponse, error) {
 	req := &evmtypes.QueryBaseFeeRequest{}
 	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.evmQueryClient.BaseFee, req)
+	return res, err
+}
+
+// Insurance module
+
+func (c *chainClient) FetchInsuranceFund(ctx context.Context, marketId string) (*insurancetypes.QueryInsuranceFundResponse, error) {
+	req := &insurancetypes.QueryInsuranceFundRequest{
+		MarketId: marketId,
+	}
+	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.insuranceQueryClient.InsuranceFund, req)
+	return res, err
+}
+
+func (c *chainClient) FetchInsuranceFunds(ctx context.Context) (*insurancetypes.QueryInsuranceFundsResponse, error) {
+	req := &insurancetypes.QueryInsuranceFundsRequest{}
+	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.insuranceQueryClient.InsuranceFunds, req)
+	return res, err
+}
+
+func (c *chainClient) FetchPendingRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryPendingRedemptionsResponse, error) {
+	req := &insurancetypes.QueryPendingRedemptionsRequest{
+		MarketId: marketId,
+		Address:  address,
+	}
+	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.insuranceQueryClient.PendingRedemptions, req)
+	return res, err
+}
+
+func (c *chainClient) FetchEstimatedRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryEstimatedRedemptionsResponse, error) {
+	req := &insurancetypes.QueryEstimatedRedemptionsRequest{
+		MarketId: marketId,
+		Address:  address,
+	}
+	res, err := common.ExecuteCall(ctx, c.network.ChainCookieAssistant, c.insuranceQueryClient.EstimatedRedemptions, req)
 	return res, err
 }
 

--- a/client/chain/chain_test_support.go
+++ b/client/chain/chain_test_support.go
@@ -28,6 +28,7 @@ import (
 	evmtypes "github.com/InjectiveLabs/sdk-go/chain/evm/types"
 	exchangetypes "github.com/InjectiveLabs/sdk-go/chain/exchange/types"
 	exchangev2types "github.com/InjectiveLabs/sdk-go/chain/exchange/types/v2"
+	insurancetypes "github.com/InjectiveLabs/sdk-go/chain/insurance/types"
 	permissionstypes "github.com/InjectiveLabs/sdk-go/chain/permissions/types"
 	chainstreamtypes "github.com/InjectiveLabs/sdk-go/chain/stream/types"
 	chainstreamv2types "github.com/InjectiveLabs/sdk-go/chain/stream/types/v2"
@@ -1207,6 +1208,24 @@ func (c *MockChainClient) FetchEVMCode(ctx context.Context, address string) (*ev
 
 func (c *MockChainClient) FetchEVMBaseFee(ctx context.Context) (*evmtypes.QueryBaseFeeResponse, error) {
 	return &evmtypes.QueryBaseFeeResponse{}, nil
+}
+
+// Insurance module
+
+func (c *MockChainClient) FetchInsuranceFund(ctx context.Context, marketId string) (*insurancetypes.QueryInsuranceFundResponse, error) {
+	return &insurancetypes.QueryInsuranceFundResponse{}, nil
+}
+
+func (c *MockChainClient) FetchInsuranceFunds(ctx context.Context) (*insurancetypes.QueryInsuranceFundsResponse, error) {
+	return &insurancetypes.QueryInsuranceFundsResponse{}, nil
+}
+
+func (c *MockChainClient) FetchPendingRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryPendingRedemptionsResponse, error) {
+	return &insurancetypes.QueryPendingRedemptionsResponse{}, nil
+}
+
+func (c *MockChainClient) FetchEstimatedRedemptions(ctx context.Context, marketId string, address string) (*insurancetypes.QueryEstimatedRedemptionsResponse, error) {
+	return &insurancetypes.QueryEstimatedRedemptionsResponse{}, nil
 }
 
 func (c *MockChainClient) CurrentChainGasPrice() int64 {

--- a/examples/chain/insurance/1_InsuranceFund/example.go
+++ b/examples/chain/insurance/1_InsuranceFund/example.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		"",
+		nil,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	chainClient, err := chainclient.NewChainClient(
+		clientCtx,
+		network,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0xfc615d2dfe6cc437c77c0d2b1721bba6947f821ce45c1aa4094dcdf333f46881"
+
+	res, err := chainClient.FetchInsuranceFund(ctx, marketId)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/chain/insurance/2_InsuranceFunds/example.go
+++ b/examples/chain/insurance/2_InsuranceFunds/example.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		"",
+		nil,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	chainClient, err := chainclient.NewChainClient(
+		clientCtx,
+		network,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	res, err := chainClient.FetchInsuranceFunds(ctx)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/chain/insurance/3_PendingRedemptions/example.go
+++ b/examples/chain/insurance/3_PendingRedemptions/example.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	userAddress, _, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		"",
+		nil,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	chainClient, err := chainclient.NewChainClient(
+		clientCtx,
+		network,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0xfc615d2dfe6cc437c77c0d2b1721bba6947f821ce45c1aa4094dcdf333f46881"
+	userAddressStr := userAddress.String()
+
+	res, err := chainClient.FetchPendingRedemptions(ctx, marketId, userAddressStr)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}

--- a/examples/chain/insurance/4_EstimatedRedemptions/example.go
+++ b/examples/chain/insurance/4_EstimatedRedemptions/example.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/InjectiveLabs/sdk-go/client"
+	chainclient "github.com/InjectiveLabs/sdk-go/client/chain"
+	"github.com/InjectiveLabs/sdk-go/client/common"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+func main() {
+	network := common.LoadNetwork("testnet", "lb")
+	tmClient, err := rpchttp.New(network.TmEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	userAddress, _, err := chainclient.InitCosmosKeyring(
+		os.Getenv("HOME")+"/.injectived",
+		"injectived",
+		"file",
+		"inj-user",
+		"12345678",
+		"5d386fbdbf11f1141010f81a46b40f94887367562bd33b452bbaa6ce1cd1381e", // keyring will be used if pk not provided
+		false,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx, err := chainclient.NewClientContext(
+		network.ChainId,
+		"",
+		nil,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx = clientCtx.WithNodeURI(network.TmEndpoint).WithClient(tmClient)
+
+	chainClient, err := chainclient.NewChainClient(
+		clientCtx,
+		network,
+		common.OptionGasPrices(client.DefaultGasPriceWithDenom),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	marketId := "0xfc615d2dfe6cc437c77c0d2b1721bba6947f821ce45c1aa4094dcdf333f46881"
+	userAddressStr := userAddress.String()
+
+	res, err := chainClient.FetchEstimatedRedemptions(ctx, marketId, userAddressStr)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	str, _ := json.MarshalIndent(res, "", " ")
+	fmt.Print(string(str))
+}


### PR DESCRIPTION
This PR adds support for querying the Insurance module via the chain gRPC API.

While we already expose Insurance data through the Exchange API, it lacks support for historic queries (i.e., queries by block height). This addition enables clients to query Insurance module state at any given block height using standard Cosmos SDK gRPC query methods.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for querying insurance fund data, pending redemptions, and estimated redemptions.
  - Introduced new example programs demonstrating how to fetch insurance fund information, all insurance funds, pending redemptions, and estimated redemptions from the blockchain.
- **Tests**
  - Updated mock client to support insurance fund and redemption query methods for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->