### PR TITLE
fix: Register EVM types in the interface registry

### DIFF
--- a/client/chain/context.go
+++ b/client/chain/context.go
@@ -134,6 +134,7 @@ func NewClientContext(
 	interfaceRegistry := NewInterfaceRegistry()
 	keyscodec.RegisterInterfaces(interfaceRegistry)
 	std.RegisterInterfaces(interfaceRegistry)
+	evmtypes.RegisterInterfaces(interfaceRegistry)
 	exchange.RegisterInterfaces(interfaceRegistry)
 	exchangev2.RegisterInterfaces(interfaceRegistry)
 	insurance.RegisterInterfaces(interfaceRegistry)


### PR DESCRIPTION
Register evm types so messages like `injective.evm.v1.MsgEthereumTx` can be decoded properly.