### PR TITLE
feat: remove unused exchange client dependency

### DIFF
--- a/client/chain/markets_assistant.go
+++ b/client/chain/markets_assistant.go
@@ -8,7 +8,6 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/InjectiveLabs/sdk-go/client/core"
-	"github.com/InjectiveLabs/sdk-go/client/exchange"
 )
 
 type TokenMetadata interface {
@@ -56,7 +55,9 @@ func NewHumanReadableMarketsAssistant(ctx context.Context, chainClient ChainClie
 	return assistant, err
 }
 
-func NewMarketsAssistantWithAllTokens(ctx context.Context, exchangeClient exchange.ExchangeClient, chainClient ChainClient) (MarketsAssistant, error) {
+// NewMarketsAssistantWithAllTokens initializes a MarketsAssistant by first fetching all token metadata from the chain's bank module
+// @deprecated removed exchangeClient
+func NewMarketsAssistantWithAllTokens(ctx context.Context, exchangeClient any, chainClient ChainClient) (MarketsAssistant, error) {
 	assistant := newMarketsAssistant()
 	assistant.initializeTokensFromChainDenoms(ctx, chainClient)
 	err := assistant.initializeFromChainV1Markets(ctx, chainClient)
@@ -64,7 +65,9 @@ func NewMarketsAssistantWithAllTokens(ctx context.Context, exchangeClient exchan
 	return assistant, err
 }
 
-func NewHumanReadableMarketsAssistantWithAllTokens(ctx context.Context, exchangeClient exchange.ExchangeClient, chainClient ChainClientV2) (MarketsAssistant, error) {
+// NewHumanReadableMarketsAssistantWithAllTokens initializes a MarketsAssistant by first fetching all token metadata from the chain's bank module
+// @deprecated removed exchangeClient
+func NewHumanReadableMarketsAssistantWithAllTokens(ctx context.Context, exchangeClient any, chainClient ChainClientV2) (MarketsAssistant, error) {
 	assistant := newMarketsAssistant()
 	assistant.initializeTokensFromChainDenoms(ctx, chainClient)
 	err := assistant.initializeFromChainV2Markets(ctx, chainClient)

--- a/client/chain/markets_assistant_test.go
+++ b/client/chain/markets_assistant_test.go
@@ -16,7 +16,6 @@ import (
 	exchangev2types "github.com/InjectiveLabs/sdk-go/chain/exchange/types/v2"
 	"github.com/InjectiveLabs/sdk-go/client/common"
 	"github.com/InjectiveLabs/sdk-go/client/core"
-	"github.com/InjectiveLabs/sdk-go/client/exchange"
 )
 
 func TestMarketAssistantCreation(t *testing.T) {
@@ -179,8 +178,6 @@ func TestMarketAssistantCreationWithAllTokens(t *testing.T) {
 	network := common.NewNetwork()
 	network.OfficialTokensListURL = httpServer.URL
 
-	mockExchange := exchange.MockExchangeClient{}
-	mockExchange.Network = network
 	mockChain := MockChainClient{}
 	smartDenomMetadata := createSmartDenomMetadata()
 
@@ -193,7 +190,7 @@ func TestMarketAssistantCreationWithAllTokens(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	assistant, err := NewMarketsAssistantWithAllTokens(ctx, &mockExchange, &mockChain)
+	assistant, err := NewMarketsAssistantWithAllTokens(ctx, nil, &mockChain)
 
 	assert.NoError(t, err)
 
@@ -365,8 +362,6 @@ func TestHumanReadableMarketAssistantCreationWithAllTokens(t *testing.T) {
 	network := common.NewNetwork()
 	network.OfficialTokensListURL = httpServer.URL
 
-	mockExchange := exchange.MockExchangeClient{}
-	mockExchange.Network = network
 	mockChain := MockChainClientV2{}
 	smartDenomMetadata := createSmartDenomMetadata()
 
@@ -379,7 +374,7 @@ func TestHumanReadableMarketAssistantCreationWithAllTokens(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	assistant, err := NewHumanReadableMarketsAssistantWithAllTokens(ctx, &mockExchange, &mockChain)
+	assistant, err := NewHumanReadableMarketsAssistantWithAllTokens(ctx, nil, &mockChain)
 
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR removes an unused dependency between chain and exchange client, it prevents circular dependencies in the clients too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Decoupled market assistant initialization from a specific exchange client, improving flexibility and forward compatibility.
  * No changes to user-facing behavior or performance.

* **Tests**
  * Simplified test setup by removing external client mocks, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->