### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/chain/evm/types/errors.go
+++ b/chain/evm/types/errors.go
@@ -292,7 +292,7 @@ func (e *RevertError) ErrorCode() int {
 }
 
 // ErrorData returns the hex encoded revert reason.
-func (e *RevertError) ErrorData() interface{} {
+func (e *RevertError) ErrorData() any {
 	return e.reason
 }
 

--- a/chain/evm/types/params.go
+++ b/chain/evm/types/params.go
@@ -113,7 +113,7 @@ func (p Params) IsAuthorisedDeployer(addr ethcommon.Address) bool {
 	return false
 }
 
-func ValidateEVMDenom(i interface{}) error {
+func ValidateEVMDenom(i any) error {
 	denom, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter EVM denom type: %T", i)
@@ -122,7 +122,7 @@ func ValidateEVMDenom(i interface{}) error {
 	return sdk.ValidateDenom(denom)
 }
 
-func ValidateBool(i interface{}) error {
+func ValidateBool(i any) error {
 	_, ok := i.(bool)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -130,7 +130,7 @@ func ValidateBool(i interface{}) error {
 	return nil
 }
 
-func validateEIPs(i interface{}) error {
+func validateEIPs(i any) error {
 	eips, ok := i.([]int64)
 	if !ok {
 		return fmt.Errorf("invalid EIP slice type: %T", i)
@@ -144,7 +144,7 @@ func validateEIPs(i interface{}) error {
 	return nil
 }
 
-func ValidateChainConfig(i interface{}) error {
+func ValidateChainConfig(i any) error {
 	cfg, ok := i.(ChainConfig)
 	if !ok {
 		return fmt.Errorf("invalid chain config type: %T", i)

--- a/chain/exchange/types/common_order.go
+++ b/chain/exchange/types/common_order.go
@@ -129,9 +129,9 @@ func ComputeOrderHash(marketId, subaccountId, feeRecipient, price, quantity, mar
 		Salt:              "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	var message = map[string]interface{}{
+	var message = map[string]any{
 		"MarketId": marketId,
-		"OrderInfo": map[string]interface{}{
+		"OrderInfo": map[string]any{
 			"SubaccountId": subaccountId,
 			"FeeRecipient": feeRecipient,
 			"Price":        price,

--- a/chain/exchange/types/params.go
+++ b/chain/exchange/types/params.go
@@ -238,7 +238,7 @@ func ValidateFixedGasFlag(enabled any) error {
 	return nil
 }
 
-func ValidateSpotMarketInstantListingFee(i interface{}) error {
+func ValidateSpotMarketInstantListingFee(i any) error {
 	v, ok := i.(sdk.Coin)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -251,7 +251,7 @@ func ValidateSpotMarketInstantListingFee(i interface{}) error {
 	return nil
 }
 
-func ValidateDerivativeMarketInstantListingFee(i interface{}) error {
+func ValidateDerivativeMarketInstantListingFee(i any) error {
 	v, ok := i.(sdk.Coin)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -264,7 +264,7 @@ func ValidateDerivativeMarketInstantListingFee(i interface{}) error {
 	return nil
 }
 
-func ValidateBinaryOptionsMarketInstantListingFee(i interface{}) error {
+func ValidateBinaryOptionsMarketInstantListingFee(i any) error {
 	v, ok := i.(sdk.Coin)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -277,7 +277,7 @@ func ValidateBinaryOptionsMarketInstantListingFee(i interface{}) error {
 	return nil
 }
 
-func ValidateFee(i interface{}) error {
+func ValidateFee(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -297,7 +297,7 @@ func ValidateFee(i interface{}) error {
 	return nil
 }
 
-func ValidateMakerFee(i interface{}) error {
+func ValidateMakerFee(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -318,7 +318,7 @@ func ValidateMakerFee(i interface{}) error {
 	return nil
 }
 
-func ValidateHourlyFundingRateCap(i interface{}) error {
+func ValidateHourlyFundingRateCap(i any) error {
 	v, ok := i.(math.LegacyDec)
 
 	if !ok {
@@ -344,7 +344,7 @@ func ValidateHourlyFundingRateCap(i interface{}) error {
 	return nil
 }
 
-func ValidateHourlyInterestRate(i interface{}) error {
+func ValidateHourlyInterestRate(i any) error {
 	v, ok := i.(math.LegacyDec)
 
 	if !ok {
@@ -366,7 +366,7 @@ func ValidateHourlyInterestRate(i interface{}) error {
 	return nil
 }
 
-func ValidateTickSize(i interface{}) error {
+func ValidateTickSize(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -426,7 +426,7 @@ func ValidateTickSize(i interface{}) error {
 	return nil
 }
 
-func ValidateMinNotional(i interface{}) error {
+func ValidateMinNotional(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -443,7 +443,7 @@ func ValidateMinNotional(i interface{}) error {
 	return nil
 }
 
-func ValidateMarginRatio(i interface{}) error {
+func ValidateMarginRatio(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -462,7 +462,7 @@ func ValidateMarginRatio(i interface{}) error {
 	return nil
 }
 
-func ValidateFundingInterval(i interface{}) error {
+func ValidateFundingInterval(i any) error {
 	v, ok := i.(int64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -475,7 +475,7 @@ func ValidateFundingInterval(i interface{}) error {
 	return nil
 }
 
-func ValidatePostOnlyModeHeightThreshold(i interface{}) error {
+func ValidatePostOnlyModeHeightThreshold(i any) error {
 	v, ok := i.(int64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -488,7 +488,7 @@ func ValidatePostOnlyModeHeightThreshold(i interface{}) error {
 	return nil
 }
 
-func ValidateAdmins(i interface{}) error {
+func ValidateAdmins(i any) error {
 	v, ok := i.([]string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -511,7 +511,7 @@ func ValidateAdmins(i interface{}) error {
 	return nil
 }
 
-func ValidateFundingMultiple(i interface{}) error {
+func ValidateFundingMultiple(i any) error {
 	v, ok := i.(int64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -524,7 +524,7 @@ func ValidateFundingMultiple(i interface{}) error {
 	return nil
 }
 
-func ValidateDerivativeOrderSideCount(i interface{}) error {
+func ValidateDerivativeOrderSideCount(i any) error {
 	v, ok := i.(uint32)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -537,7 +537,7 @@ func ValidateDerivativeOrderSideCount(i interface{}) error {
 	return nil
 }
 
-func ValidateInjRewardStakedRequirementThreshold(i interface{}) error {
+func ValidateInjRewardStakedRequirementThreshold(i any) error {
 	v, ok := i.(math.Int)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -554,7 +554,7 @@ func ValidateInjRewardStakedRequirementThreshold(i interface{}) error {
 	return nil
 }
 
-func ValidateTradingRewardsVestingDuration(i interface{}) error {
+func ValidateTradingRewardsVestingDuration(i any) error {
 	v, ok := i.(int64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -567,7 +567,7 @@ func ValidateTradingRewardsVestingDuration(i interface{}) error {
 	return nil
 }
 
-func ValidateLiquidatorRewardShareRate(i interface{}) error {
+func ValidateLiquidatorRewardShareRate(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -586,7 +586,7 @@ func ValidateLiquidatorRewardShareRate(i interface{}) error {
 	return nil
 }
 
-func ValidateAtomicMarketOrderAccessLevel(i interface{}) error {
+func ValidateAtomicMarketOrderAccessLevel(i any) error {
 	v, ok := i.(AtomicMarketOrderAccessLevel)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -597,7 +597,7 @@ func ValidateAtomicMarketOrderAccessLevel(i interface{}) error {
 	return nil
 }
 
-func ValidateAtomicMarketOrderFeeMultiplier(i interface{}) error {
+func ValidateAtomicMarketOrderFeeMultiplier(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -615,7 +615,7 @@ func ValidateAtomicMarketOrderFeeMultiplier(i interface{}) error {
 	return nil
 }
 
-func ValidateBool(i interface{}) error {
+func ValidateBool(i any) error {
 	_, ok := i.(bool)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/chain/exchange/types/paramset.go
+++ b/chain/exchange/types/paramset.go
@@ -1,19 +1,19 @@
 package types
 
 type (
-	ValueValidatorFn func(value interface{}) error
+	ValueValidatorFn func(value any) error
 
 	// ParamSetPair is used for associating paramsubspace key and field of param
 	// structs.
 	ParamSetPair struct {
 		Key         []byte
-		Value       interface{}
+		Value       any
 		ValidatorFn ValueValidatorFn
 	}
 )
 
 // NewParamSetPair creates a new ParamSetPair instance.
-func NewParamSetPair(key []byte, value interface{}, vfn ValueValidatorFn) ParamSetPair {
+func NewParamSetPair(key []byte, value any, vfn ValueValidatorFn) ParamSetPair {
 	return ParamSetPair{key, value, vfn}
 }
 

--- a/chain/exchange/types/spot_orders.go
+++ b/chain/exchange/types/spot_orders.go
@@ -30,9 +30,9 @@ func ComputeSpotOrderHash(marketId, orderType, triggerPrice string, orderInfo IO
 		Salt:              "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	var message = map[string]interface{}{
+	var message = map[string]any{
 		"MarketId": marketId,
-		"OrderInfo": map[string]interface{}{
+		"OrderInfo": map[string]any{
 			"SubaccountId": orderInfo.GetSubaccountId(),
 			"FeeRecipient": orderInfo.GetFeeRecipient(),
 			"Price":        orderInfo.GetPrice().String(),

--- a/chain/oracle/types/params.go
+++ b/chain/oracle/types/params.go
@@ -85,7 +85,7 @@ func DefaultTestBandIbcParams() *BandIBCParams {
 	}
 }
 
-func validatePythContract(i interface{}) error {
+func validatePythContract(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/chain/peggy/types/params.go
+++ b/chain/peggy/types/params.go
@@ -118,7 +118,7 @@ func (p Params) Equal(p2 Params) bool {
 	return bytes.Equal(bz1, bz2)
 }
 
-func validatePeggyID(i interface{}) error {
+func validatePeggyID(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -129,28 +129,28 @@ func validatePeggyID(i interface{}) error {
 	return nil
 }
 
-func validateContractHash(i interface{}) error {
+func validateContractHash(i any) error {
 	if _, ok := i.(string); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateBridgeChainID(i interface{}) error {
+func validateBridgeChainID(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateBridgeContractStartHeight(i interface{}) error {
+func validateBridgeContractStartHeight(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateTargetBatchTimeout(i interface{}) error {
+func validateTargetBatchTimeout(i any) error {
 	val, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -160,7 +160,7 @@ func validateTargetBatchTimeout(i interface{}) error {
 	return nil
 }
 
-func validateAverageBlockTime(i interface{}) error {
+func validateAverageBlockTime(i any) error {
 	val, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -170,7 +170,7 @@ func validateAverageBlockTime(i interface{}) error {
 	return nil
 }
 
-func validateAverageEthereumBlockTime(i interface{}) error {
+func validateAverageEthereumBlockTime(i any) error {
 	val, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -180,7 +180,7 @@ func validateAverageEthereumBlockTime(i interface{}) error {
 	return nil
 }
 
-func validateBridgeContractAddress(i interface{}) error {
+func validateBridgeContractAddress(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -193,56 +193,56 @@ func validateBridgeContractAddress(i interface{}) error {
 	return nil
 }
 
-func validateSignedValsetsWindow(i interface{}) error {
+func validateSignedValsetsWindow(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateUnbondSlashingValsetsWindow(i interface{}) error {
+func validateUnbondSlashingValsetsWindow(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSlashFractionValset(i interface{}) error {
+func validateSlashFractionValset(i any) error {
 	if _, ok := i.(math.LegacyDec); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSignedBatchesWindow(i interface{}) error {
+func validateSignedBatchesWindow(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSignedClaimsWindow(i interface{}) error {
+func validateSignedClaimsWindow(i any) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSlashFractionBatch(i interface{}) error {
+func validateSlashFractionBatch(i any) error {
 	if _, ok := i.(math.LegacyDec); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSlashFractionClaim(i interface{}) error {
+func validateSlashFractionClaim(i any) error {
 	if _, ok := i.(math.LegacyDec); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateSlashFractionConflictingClaim(i interface{}) error {
+func validateSlashFractionConflictingClaim(i any) error {
 	if _, ok := i.(math.LegacyDec); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
@@ -258,7 +258,7 @@ func strToFixByteArray(s string) ([32]byte, error) {
 	return out, nil
 }
 
-func validateCosmosCoinDenom(i interface{}) error {
+func validateCosmosCoinDenom(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -270,7 +270,7 @@ func validateCosmosCoinDenom(i interface{}) error {
 	return nil
 }
 
-func validateCosmosCoinErc20Contract(i interface{}) error {
+func validateCosmosCoinErc20Contract(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -284,7 +284,7 @@ func validateCosmosCoinErc20Contract(i interface{}) error {
 	return ValidateEthAddress(v)
 }
 
-func validateClaimSlashingEnabled(i interface{}) error {
+func validateClaimSlashingEnabled(i any) error {
 	_, ok := i.(bool)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -292,18 +292,18 @@ func validateClaimSlashingEnabled(i interface{}) error {
 	return nil
 }
 
-func validateSlashFractionBadEthSignature(i interface{}) error {
+func validateSlashFractionBadEthSignature(i any) error {
 	if _, ok := i.(math.LegacyDec); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 	return nil
 }
 
-func validateValsetReward(i interface{}) error {
+func validateValsetReward(i any) error {
 	return nil
 }
 
-func validateAdmins(i interface{}) error {
+func validateAdmins(i any) error {
 	v, ok := i.([]string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -326,7 +326,7 @@ func validateAdmins(i interface{}) error {
 	return nil
 }
 
-func validateSegregatedWallet(i interface{}) error {
+func validateSegregatedWallet(i any) error {
 	str, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/chain/wasmx/types/custom_execution.go
+++ b/chain/wasmx/types/custom_execution.go
@@ -13,9 +13,9 @@ type InjectiveExecMsg struct {
 }
 
 type ExecutionData struct {
-	Origin string      `json:"origin"`
-	Name   string      `json:"name"`
-	Args   interface{} `json:"args"`
+	Origin string `json:"origin"`
+	Name   string `json:"name"`
+	Args   any    `json:"args"`
 }
 
 func NewInjectiveExecMsg(origin sdk.AccAddress, data string) (*InjectiveExecMsg, error) {

--- a/chain/wasmx/types/params.go
+++ b/chain/wasmx/types/params.go
@@ -102,7 +102,7 @@ func (p Params) Validate() error {
 	return nil
 }
 
-func validateMaxBeginBlockTotalGas(i interface{}) error {
+func validateMaxBeginBlockTotalGas(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -115,7 +115,7 @@ func validateMaxBeginBlockTotalGas(i interface{}) error {
 	return nil
 }
 
-func validateMaxContractGasLimit(i interface{}) error {
+func validateMaxContractGasLimit(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -127,7 +127,7 @@ func validateMaxContractGasLimit(i interface{}) error {
 	return nil
 }
 
-func validateIsExecutionEnabled(i interface{}) error {
+func validateIsExecutionEnabled(i any) error {
 	_, ok := i.(bool)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -136,7 +136,7 @@ func validateIsExecutionEnabled(i interface{}) error {
 	return nil
 }
 
-func validateMinGasPrice(i interface{}) error {
+func validateMinGasPrice(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -148,7 +148,7 @@ func validateMinGasPrice(i interface{}) error {
 	return nil
 }
 
-func validateAccessConfig(i interface{}) error {
+func validateAccessConfig(i any) error {
 	v, ok := i.(wasmtypes.AccessConfig)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -2929,9 +2929,9 @@ func (c *chainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, d
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),
@@ -2971,9 +2971,9 @@ func (c *chainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, d
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),

--- a/client/chain/chain_v2.go
+++ b/client/chain/chain_v2.go
@@ -2745,9 +2745,9 @@ func (c *chainClientV2) ComputeOrderHashes(spotOrders []exchangev2types.SpotOrde
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),
@@ -2787,9 +2787,9 @@ func (c *chainClientV2) ComputeOrderHashes(spotOrders []exchangev2types.SpotOrde
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),

--- a/eip712_cosmos.go
+++ b/eip712_cosmos.go
@@ -119,7 +119,7 @@ func WrapTxToEIP712WithSignBytes(
 	feePayer cosmtypes.AccAddress,
 	timeoutHeight uint64,
 ) (typeddata.TypedData, error) {
-	txData := make(map[string]interface{})
+	txData := make(map[string]any)
 	if err := json.Unmarshal(signBytes, &txData); err != nil {
 		err = fmt.Errorf("failed to unmarshal data provided into WrapTxToEIP712: %w", err)
 		return typeddata.TypedData{}, err
@@ -139,7 +139,7 @@ func WrapTxToEIP712WithSignBytes(
 	}
 
 	if feePayer != nil {
-		feeInfo := txData["fee"].(map[string]interface{})
+		feeInfo := txData["fee"].(map[string]any)
 		feeInfo["feePayer"] = feePayer.String()
 
 		// also patching msgTypes to include feePayer
@@ -210,7 +210,7 @@ func WrapTxToEIP712V2(
 		return typeddata.TypedData{}, fmt.Errorf("marshal fee info failed: %w", err)
 	}
 
-	ctx := map[string]interface{}{
+	ctx := map[string]any{
 		"account_number": signerData.AccountNumber,
 		"sequence":       signerData.Sequence,
 		"timeout_height": tx.GetTimeoutHeight(),

--- a/ethereum/util/amounts.go
+++ b/ethereum/util/amounts.go
@@ -22,7 +22,7 @@ func (w Wei) Bytes() []byte {
 	return []byte(decimal.Decimal(w).String())
 }
 
-func (w *Wei) Scan(v interface{}) error {
+func (w *Wei) Scan(v any) error {
 	if v == nil {
 		return nil
 	}

--- a/ethereum/util/contract.go
+++ b/ethereum/util/contract.go
@@ -87,7 +87,7 @@ func (contract *BoundContract) ABI() abi.ABI {
 	return contract.abi
 }
 
-func (c *BoundContract) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+func (c *BoundContract) Transact(opts *bind.TransactOpts, method string, params ...any) (*types.Transaction, error) {
 	if c.transactFn == nil {
 		return c.BoundContract.Transact(opts, method, params...)
 	}

--- a/examples/chain/11_DecodeTx/37_decode_tx.go
+++ b/examples/chain/11_DecodeTx/37_decode_tx.go
@@ -8,7 +8,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-var parserMap = map[string]interface{}{
+var parserMap = map[string]any{
 	"/cosmos.bank.v1beta1.MsgSend":      banktypes.MsgSend{},
 	"/cosmos.bank.v1beta1.MsgMultiSend": banktypes.MsgMultiSend{},
 }


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type system across multiple modules for Go 1.18+ compatibility with no functional impact.

* **Bug Fixes**
  * Enhanced parameter validations in blockchain modules to enforce stricter minimum value requirements and address validation constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->