### PR TITLE
refactor(client): replace interface{} with any in chain client

### DIFF
--- a/client/chain/chain.go
+++ b/client/chain/chain.go
@@ -2932,9 +2932,9 @@ func (c *chainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, d
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),
@@ -2974,9 +2974,9 @@ func (c *chainClient) ComputeOrderHashes(spotOrders []exchangetypes.SpotOrder, d
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),

--- a/client/chain/chain_v2.go
+++ b/client/chain/chain_v2.go
@@ -2745,9 +2745,9 @@ func (c *chainClientV2) ComputeOrderHashes(spotOrders []exchangev2types.SpotOrde
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),
@@ -2787,9 +2787,9 @@ func (c *chainClientV2) ComputeOrderHashes(spotOrders []exchangev2types.SpotOrde
 		if o.TriggerPrice != nil {
 			triggerPrice = o.TriggerPrice.String()
 		}
-		message := map[string]interface{}{
+		message := map[string]any{
 			"MarketId": o.MarketId,
-			"OrderInfo": map[string]interface{}{
+			"OrderInfo": map[string]any{
 				"SubaccountId": o.OrderInfo.SubaccountId,
 				"FeeRecipient": o.OrderInfo.FeeRecipient,
 				"Price":        o.OrderInfo.Price.String(),


### PR DESCRIPTION
## Summary

Modernize 8 occurrences of `map[string]interface{}` to `map[string]any` in `ComputeOrderHashes` for both `ChainClient` and `ChainClientV2`.

### Motivation

Go 1.18+ provides `any` as a built-in alias for `interface{}`. This is a purely cosmetic change with **zero behavioral impact**, improving readability and aligning with modern Go idioms.

Related: #349

### Changes

| File | Change |
|------|--------|
| `client/chain/chain.go` | `map[string]interface{}` → `map[string]any` (4 occurrences) |
| `client/chain/chain_v2.go` | `map[string]interface{}` → `map[string]any` (4 occurrences) |

### Verification

- `go build ./client/...` ✓
- `go vet ./client/...` ✓
- No test changes needed (zero behavioral change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type declarations in order computation components for improved code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->